### PR TITLE
feat: support force re-registration of all daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ pilot-manager setup ~/projects --server http://localhost:3000 --yes
 
 | Command | Description |
 |---------|-------------|
-| `install [name]` | Generate plist + start via launchd |
-| `uninstall [name]` | Stop + remove plist |
-| `start [name]` | Start service |
-| `stop [name]` | Stop service |
-| `restart [name]` | Stop + regenerate plist + start |
+| `install [name]` | Generate plist + start via launchd (all if no name) |
+| `uninstall [name]` | Stop + remove plist (all if no name) |
+| `start [name]` | Start service (all if no name) |
+| `stop [name]` | Stop service (all if no name) |
+| `restart [name]` | Stop + regenerate plist + start (all if no name) |
 | `reinstall [name]` | Alias for restart (picks up config changes) |
 | `logs <name> [--stdout]` | Tail daemon logs |
 
@@ -58,7 +58,7 @@ pilot-manager setup ~/projects --server http://localhost:3000 --yes
 
 | Command | Description |
 |---------|-------------|
-| `register [name] [--server URL] [--force]` | Register with Rails server |
+| `register [name] [--server URL] [--force]` | Register with Rails server (all if no name) |
 | `deregister [name]` | Revoke token and clear from config |
 | `token <name> [--reveal]` | Show auth token |
 | `setup <dir> [--server URL] [--yes]` | Scan + register + install in one step |
@@ -102,6 +102,23 @@ projects:
     extra_env:
       CUSTOM_VAR: value
 ```
+
+## Re-registering Daemons
+
+If the server is reset or tokens become invalid, daemons will fail to connect and launchd will restart them in a loop. To recover:
+
+```bash
+# 1. Stop all daemons (breaks the restart loop)
+pilot-manager stop
+
+# 2. Force re-register all projects (revokes old tokens, gets new ones)
+pilot-manager register --force
+
+# 3. Reinstall all services (regenerates plists with new tokens + starts)
+pilot-manager reinstall
+```
+
+The `--force` flag suspends the existing pilot registration on the server and creates a fresh one with a new auth token.
 
 ## How It Works
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,12 +34,12 @@ Service Commands:
   uninstall [name]               Stop + remove plist (all or one)
   start [name]                   Start service via launchctl load
   stop [name]                    Stop service via launchctl unload
-  restart [name]                 Stop + regenerate plist + start
+  restart [name]                 Stop + regenerate plist + start (all if no name)
   reinstall [name]               Alias for restart (picks up config changes)
   logs <name> [--stdout]         Tail a daemon's log
 
 Registration Commands:
-  register [name] [--server URL] [--force]  Register with Rails server
+  register [name] [--server URL] [--force]  Register with Rails server (all if no name)
   deregister [name]              Revoke token and clear from config
   token <name> [--reveal]        Show auth token for a project
   setup <dir> [--server URL] [--yes]  Scan + register + install in one step

--- a/src/registrar.js
+++ b/src/registrar.js
@@ -12,7 +12,7 @@ function getPackageVersion() {
   }
 }
 
-export async function registerPilot(serverUrl, projectName, projectConfig) {
+export async function registerPilot(serverUrl, projectName, projectConfig, options = {}) {
   const globalConfig = loadConfig();
   const version = getPackageVersion();
   const maxSessions = globalConfig.max_sessions_per_project || 10;
@@ -44,6 +44,7 @@ export async function registerPilot(serverUrl, projectName, projectConfig) {
         'session_recover',
       ],
     },
+    force: options.force || false,
   };
 
   let response;
@@ -121,7 +122,17 @@ export async function registerProject(name, options = {}) {
   const globalConfig = loadConfig();
   const serverUrl = options.server || globalConfig.server_url;
 
-  const result = await registerPilot(serverUrl, name, project);
+  // If force re-registering, revoke the old token first (ignore failures —
+  // the token may already be invalid, which is fine)
+  if (options.force && project.auth_token) {
+    try {
+      await revokeToken(serverUrl, project.auth_token);
+    } catch {
+      // Token may already be invalid or server may have purged it — proceed
+    }
+  }
+
+  const result = await registerPilot(serverUrl, name, project, options);
 
   // Save token to registry
   const data = loadProjects();


### PR DESCRIPTION
## Summary
- Adds proper --force support to register so it works for all projects at once
- Sends force param to server to suspend existing pilot before re-registering
- Gracefully attempts to revoke old tokens before re-registering (handles already-invalid tokens)
- Updated help text and README to clarify bulk operation when no name is given
- Documented recovery workflow: stop, register --force, reinstall

## Test plan
- [x] npm test - all 18 tests pass
- [x] Manually tested register --force - all 4 projects re-registered
- [x] Manually tested reinstall - all 4 daemons running with new tokens
- [x] Verified full recovery workflow end-to-end