### PR TITLE
feat: add upgrade command for daemon versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ pilot-manager setup ~/projects --server http://localhost:3000 --yes
 | `token <name> [--reveal]` | Show auth token |
 | `setup <dir> [--server URL] [--yes]` | Scan + register + install in one step |
 
+### Other
+
+| Command | Description |
+|---------|-------------|
+| `upgrade [--version X]` | Upgrade daemon to latest (or specified) npm version and restart services |
+| `version` | Show versions (manager, daemon, node) |
+
 ## Configuration
 
 All config lives in `~/.config/claude-pilot-manager/`:

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,9 @@ import {
   registerProject, deregisterProject, registerAll,
   checkTokenStatus,
 } from './registrar.js';
+import {
+  getInstalledDaemonVersion, getLatestDaemonVersion, upgradeDaemon,
+} from './upgrade.js';
 
 const HELP = `
 pilot-manager — Per-machine supervisor for claude-session-daemon instances
@@ -45,6 +48,7 @@ Registration Commands:
   setup <dir> [--server URL] [--yes]  Scan + register + install in one step
 
 Other:
+  upgrade [--version X]          Upgrade daemon to latest (or specified) version
   version                        Show version
   help                           Show this help
 
@@ -462,6 +466,52 @@ async function cmdSetup(positionals, args) {
   cmdInstall([]);
 }
 
+function cmdUpgrade(args) {
+  const currentVersion = getInstalledDaemonVersion();
+  if (!currentVersion) {
+    console.error('Error: daemon not found. Install it first with: npm install -g @radnine/claude-session-daemon');
+    process.exit(1);
+  }
+
+  const targetVersion = args.version || null;
+  const latest = getLatestDaemonVersion();
+
+  if (!targetVersion && currentVersion === latest) {
+    console.log(`Daemon is already at the latest version (${currentVersion}).`);
+    return;
+  }
+
+  if (targetVersion && currentVersion === targetVersion) {
+    console.log(`Daemon is already at version ${currentVersion}.`);
+    return;
+  }
+
+  const target = targetVersion || latest;
+  console.log(`Upgrading daemon: ${currentVersion} → ${target}`);
+
+  const newVersion = upgradeDaemon(targetVersion);
+  console.log(`Installed daemon version ${newVersion}`);
+
+  // Reinstall all running services to pick up the new binary
+  const projects = listProjects();
+  const installed = projects.filter(p => getServiceStatus(p.name) !== 'not installed');
+
+  if (installed.length > 0) {
+    console.log(`\nRestarting ${installed.length} service(s)...`);
+    for (const p of installed) {
+      try {
+        restartService(p.name);
+        const pid = getServicePid(p.name);
+        console.log(`  Restarted "${p.name}"${pid ? ` (PID ${pid})` : ''}`);
+      } catch (err) {
+        console.error(`  Failed "${p.name}": ${err.message}`);
+      }
+    }
+  } else {
+    console.log('\nNo installed services to restart.');
+  }
+}
+
 function cmdVersion() {
   const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
   console.log(`pilot-manager: @radnine/claude-pilot-manager@${pkg.version}`);
@@ -518,6 +568,7 @@ export async function run(argv) {
         help: { type: 'boolean', short: 'h', default: false },
         stdout: { type: 'boolean', default: false },
         lines: { type: 'string' },
+        version: { type: 'string' },
       },
       allowPositionals: true,
       strict: false,
@@ -578,6 +629,9 @@ export async function run(argv) {
       break;
     case 'setup':
       await cmdSetup(parsed.positionals, parsed.values);
+      break;
+    case 'upgrade':
+      cmdUpgrade(parsed.values);
       break;
     default:
       console.error(`Unknown command: ${command}\nRun "pilot-manager help" for usage.`);

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { resolveDaemonEntry } from './launchd.js';
+
+const DAEMON_PACKAGE = '@radnine/claude-session-daemon';
+
+export function getInstalledDaemonVersion() {
+  const entry = resolveDaemonEntry();
+  if (!entry) return null;
+
+  try {
+    const pkgPath = path.resolve(entry, '..', '..', 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      return pkg.version;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export function getLatestDaemonVersion() {
+  try {
+    return execSync(`npm view ${DAEMON_PACKAGE} version`, { encoding: 'utf8' }).trim();
+  } catch {
+    throw new Error(`Cannot fetch latest version of ${DAEMON_PACKAGE} from npm`);
+  }
+}
+
+export function upgradeDaemon(targetVersion) {
+  const spec = targetVersion ? `${DAEMON_PACKAGE}@${targetVersion}` : `${DAEMON_PACKAGE}@latest`;
+
+  try {
+    execSync(`npm install -g ${spec}`, { encoding: 'utf8', stdio: 'pipe' });
+  } catch (err) {
+    throw new Error(`npm install -g ${spec} failed: ${err.message}`);
+  }
+
+  // Return the version that was actually installed
+  return getInstalledDaemonVersion();
+}


### PR DESCRIPTION
Adds a `pilot-manager upgrade` command to update the daemon to the latest (or specified) npm version and restart all services.