### PR TITLE
fix: make pilot_id machine-scoped to prevent cross-host collisions

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import yaml from 'js-yaml';
 import { PROJECTS_FILE, ensureConfigDir } from './paths.js';
 import { loadConfig } from './config.js';
@@ -66,7 +67,7 @@ export function addProject(name, projectPath, options = {}) {
   data.projects[name] = {
     path: projectPath,
     port,
-    pilot_id: `${name}-pilot`,
+    pilot_id: `${name}-pilot-${os.hostname()}`,
     auth_token: null,
     auto_restart: true,
     extra_env: {},


### PR DESCRIPTION
## Summary
- `pilot_id` was generated as `${name}-pilot`, identical across machines, causing cross-host collisions
- When two hosts registered the same project, the last WebSocket connection silently stole the pilot record
- Fix appends `os.hostname()` to make `pilot_id` unique per machine (e.g. `myapp-pilot-host1`)

## Test plan
- [ ] Register a project on two different machines and verify they get distinct `pilot_id` values
- [ ] Confirm existing single-machine registrations still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)