### PR TITLE
fix: report git remote on register so the server creates the Repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radnine/claude-pilot-manager",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Per-machine supervisor for @radnine/claude-session-daemon instances",
   "type": "module",
   "bin": {

--- a/src/registrar.js
+++ b/src/registrar.js
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import fs from 'node:fs';
+import { execSync } from 'node:child_process';
 import { loadConfig } from './config.js';
 import { getProject, loadProjects, saveProjects, listProjects } from './registry.js';
 
@@ -9,6 +10,22 @@ function getPackageVersion() {
     return pkg.version;
   } catch {
     return '0.1.0';
+  }
+}
+
+// The server find-or-creates a Repo row from the pilot's git remote (canonical
+// "org/name" → slug) so it shows up in the repo scope switcher. Report the
+// project's origin URL; '' when there's no origin (or it isn't a git repo), in
+// which case the server falls back to basename matching against known repos.
+export function gitRemoteFor(projectPath) {
+  try {
+    return execSync('git remote get-url origin', {
+      cwd: projectPath,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
   }
 }
 
@@ -25,6 +42,7 @@ export async function registerPilot(serverUrl, projectName, projectConfig, optio
       port: projectConfig.port,
       version,
       working_directory: projectConfig.path,
+      git_remote: gitRemoteFor(projectConfig.path),
       max_sessions: maxSessions,
       security_level: 'standard',
       access_scope: 'global',

--- a/test/registrar.test.js
+++ b/test/registrar.test.js
@@ -1,0 +1,104 @@
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+
+// Isolate config/registry under a temp HOME (same approach as registry.test.js)
+// so loadConfig() inside registerPilot reads defaults, not the real machine.
+const TEST_DIR = path.join(os.tmpdir(), `pilot-manager-registrar-test-${process.pid}`);
+process.env.HOME = TEST_DIR;
+fs.mkdirSync(path.join(TEST_DIR, '.config', 'claude-pilot-manager'), { recursive: true });
+
+const { gitRemoteFor, registerPilot } = await import('../src/registrar.js');
+
+// Build a throwaway git repo with the given origin and return its path.
+function makeRepo(remote) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-repo-'));
+  execSync('git init -q', { cwd: dir });
+  if (remote) execSync(`git remote add origin ${remote}`, { cwd: dir });
+  return dir;
+}
+
+describe('gitRemoteFor', () => {
+  it('returns the origin URL for a repo that has one', () => {
+    const dir = makeRepo('git@github.com:radixhound/rad-project.git');
+    try {
+      assert.equal(gitRemoteFor(dir), 'git@github.com:radixhound/rad-project.git');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns "" for a git repo with no origin remote', () => {
+    const dir = makeRepo(null);
+    try {
+      assert.equal(gitRemoteFor(dir), '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns "" for a directory that is not a git repo', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-plain-'));
+    try {
+      assert.equal(gitRemoteFor(dir), '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('registerPilot payload', () => {
+  const realFetch = global.fetch;
+  let captured;
+
+  beforeEach(() => {
+    captured = null;
+    global.fetch = async (url, opts) => {
+      captured = { url, body: JSON.parse(opts.body) };
+      return {
+        status: 201,
+        json: async () => ({
+          pilot: { pilot_id: 'p1' },
+          authentication: { api_key: 'tok_abc', token_type: 'Bearer' },
+        }),
+      };
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('includes the project git remote so the server can create the Repo', async () => {
+    const dir = makeRepo('git@github.com:radixhound/rad-project.git');
+    try {
+      await registerPilot('http://localhost:3000', 'rad-project', {
+        pilot_id: 'rad-project-pilot',
+        port: 3601,
+        path: dir,
+      });
+      assert.equal(captured.url, 'http://localhost:3000/api/pilot_auth/register');
+      assert.equal(captured.body.pilot.git_remote, 'git@github.com:radixhound/rad-project.git');
+      assert.equal(captured.body.pilot.working_directory, dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('sends an empty git_remote (not undefined) when there is no origin', async () => {
+    const dir = makeRepo(null);
+    try {
+      await registerPilot('http://localhost:3000', 'no-origin', {
+        pilot_id: 'no-origin-pilot',
+        port: 3602,
+        path: dir,
+      });
+      assert.equal(captured.body.pilot.git_remote, '');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -61,7 +61,8 @@ describe('Registry', () => {
 
     const result = addProject('my-project', tmpProject);
     assert.equal(result.port, 3601);
-    assert.equal(result.pilot_id, 'my-project-pilot');
+    // pilot_id is machine-scoped (PR #6) to avoid cross-host collisions
+    assert.equal(result.pilot_id, `my-project-pilot-${os.hostname()}`);
     assert.equal(result.auth_token, null);
 
     const projects = listProjects();


### PR DESCRIPTION
## Problem

Projects added via `pilot-manager setup` never appear in the FlightDeck sidebar's **repo scope switcher**.

## Root cause

The Rails server auto-creates a `Repo` row from a pilot's **git remote** on registration (rad-project #256 — `Api::PilotAuthController#register` → `resolve_repo_from_remote`, deriving a canonical `org/name` slug). That fix wired `git_remote` into the Ruby `bin/register_pilot` script, but **not** into this Node tool, which is what's actually used now.

`registerPilot` in `src/registrar.js` sent `working_directory` but no `git_remote`. So:

1. `pilot-manager setup` → `registerProject` → `registerPilot` posts a payload with **no `git_remote`**.
2. Server's `resolve_repo_from_remote(nil)` returns `nil` → **no `Repo` is created**.
3. The server's only fallback (`Pilot#infer_repo_from_working_directory`) **matches existing repos by basename but never creates one**, so `repo_id` stays `nil`.
4. No `Repo` row → nothing new in the sidebar dropdown (`available_repos = Repo.order(:name)`).

## Fix

`registerPilot` now reports `git remote get-url origin` for the project and includes it as `git_remote` in the payload — matching what `bin/register_pilot` already does. A directory with no `origin` (or one that isn't a git repo) sends `""`, so the server keeps its basename-matching fallback — no regression for repos already seeded.

## Tests

New `test/registrar.test.js` exercises the real machinery:
- `gitRemoteFor` against real throwaway git repos (with origin, without origin, non-repo).
- `registerPilot` with a stubbed `fetch`, asserting the posted payload carries the project's `git_remote`.

Also fixed a pre-existing, machine-dependent failure in `test/registry.test.js` (it still expected the old non-machine-scoped `pilot_id` from before PR #6) in a separate commit. Full suite: **23/23 passing**.

Version bumped 0.1.1 → 0.1.2 per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)