### PR TITLE
feat: single-project setup mode (setup <path> --name X)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radnine/claude-pilot-manager",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Per-machine supervisor for @radnine/claude-session-daemon instances",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radnine/claude-pilot-manager",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Per-machine supervisor for @radnine/claude-session-daemon instances",
   "type": "module",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,7 @@ import { ensureConfigDir, LOGS_DIR } from './paths.js';
 import {
   installService, uninstallService, restartService,
   installAll, uninstallAll,
-  getServiceStatus, getServicePid,
+  getServiceStatus, getServicePid, planServiceRefresh,
   logPath, plistPath, resolveDaemonEntry,
 } from './launchd.js';
 import {
@@ -354,6 +354,33 @@ function cmdLogs(positionals, args) {
   }
 }
 
+// After a registration saves a fresh token, an already-installed launchd service
+// still holds the OLD token in its plist's EnvironmentVariables, so the running
+// daemon keeps authenticating with a revoked credential. Bring it back in sync:
+// regenerate the plist and reload. No-op (with a note) when nothing is installed
+// yet — the token gets baked in at first install. Never throws: a refresh failure
+// after a successful registration must NOT read as a registration failure, so it's
+// reported with a `reinstall` retry pointer and returned to the caller to decide.
+function refreshServiceIfInstalled(name) {
+  const plan = planServiceRefresh(getServiceStatus(name));
+
+  if (plan.action === 'skip') {
+    console.log(`  No launchd service installed for "${name}" yet — token applies at install.`);
+    return { installed: false, refreshed: false };
+  }
+
+  try {
+    restartService(name);
+    const pid = getServicePid(name);
+    console.log(`  Reinstalled service "${name}"${pid ? ` (PID ${pid})` : ''} to apply the new token.`);
+    return { installed: true, refreshed: true, pid };
+  } catch (err) {
+    console.error(`  Token saved, but reloading the service failed: ${err.message}`);
+    console.error(`  Retry: pilot-manager reinstall ${name}`);
+    return { installed: true, refreshed: false, error: err.message };
+  }
+}
+
 async function cmdRegister(positionals, args) {
   const options = {};
   if (args.server) options.server = args.server;
@@ -369,6 +396,7 @@ async function cmdRegister(positionals, args) {
       }
       const result = await registerProject(name, options);
       console.log(`Registered "${name}" — token: ${result.auth_token?.slice(0, 8)}...`);
+      refreshServiceIfInstalled(name);
     } catch (err) {
       console.error(`Error: ${err.message}`);
       process.exit(1);
@@ -378,6 +406,7 @@ async function cmdRegister(positionals, args) {
     for (const r of results) {
       if (r.success) {
         console.log(`Registered "${r.name}" — token: ${r.auth_token?.slice(0, 8)}...`);
+        refreshServiceIfInstalled(r.name);
       } else if (r.skipped) {
         console.log(`Skipped "${r.name}" (${r.error})`);
       } else {
@@ -488,20 +517,21 @@ async function setupSingleProject(projectPath, name, args) {
   // ("already loaded") and silently skip the reload.
   console.log('\n--- Installing launchd service ---');
   const alreadyInstalled = getServiceStatus(name) !== 'not installed';
-  try {
-    if (alreadyInstalled) {
-      restartService(name);
-      const pid = getServicePid(name);
-      console.log(`Reinstalled "${name}"${pid ? ` (PID ${pid})` : ''}`);
-    } else {
+  if (alreadyInstalled) {
+    // Same rule as `register`: refresh the installed service so the freshly-saved
+    // token takes effect (a plain `launchctl load` would fail "already loaded").
+    const refresh = refreshServiceIfInstalled(name);
+    if (refresh.error) process.exit(1);
+  } else {
+    try {
       installService(name);
       const pid = getServicePid(name);
       console.log(`Installed "${name}"${pid ? ` (PID ${pid})` : ''}`);
+    } catch (err) {
+      console.error(`Registered OK, install failed: ${err.message}`);
+      console.error(`  Fix the issue, then retry: pilot-manager install ${name}`);
+      process.exit(1);
     }
-  } catch (err) {
-    console.error(`Registered OK, install failed: ${err.message}`);
-    console.error(`  Fix the issue, then retry: pilot-manager install ${name}`);
-    process.exit(1);
   }
 
   const finalPid = getServicePid(name);

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,7 +45,8 @@ Registration Commands:
   register [name] [--server URL] [--force]  Register with Rails server (all if no name)
   deregister [name]              Revoke token and clear from config
   token <name> [--reveal]        Show auth token for a project
-  setup <dir> [--server URL] [--yes]  Scan + register + install in one step
+  setup <path> --name X [--port N] [--server URL]  Add + register + install one project
+  setup <parent-dir> [--server URL] [--yes]        Scan + register + install all found
 
 Other:
   upgrade [--version X]          Upgrade daemon to latest (or specified) version
@@ -429,14 +430,94 @@ function cmdToken(positionals, args) {
   }
 }
 
-async function cmdSetup(positionals, args) {
-  const parentDir = positionals[0];
-  if (!parentDir) {
-    console.error('Error: parent directory is required. Usage: pilot-manager setup <dir> [--server URL] [--yes]');
+// Run add → register → install for a single named project, stopping at the
+// first stage that fails and pointing at the staged command to retry.
+async function setupSingleProject(projectPath, name, args) {
+  const absPath = path.resolve(projectPath);
+  if (!fs.existsSync(absPath) || !fs.statSync(absPath).isDirectory()) {
+    console.error(`Error: "${absPath}" is not a valid directory`);
     process.exit(1);
   }
 
-  // Step 1: Init if needed
+  // Stage 1: add to registry (idempotent — reuse an existing entry)
+  console.log('--- Adding to registry ---');
+  const existing = getProject(name);
+  if (existing) {
+    if (path.resolve(existing.path) !== absPath) {
+      console.error(
+        `Error: "${name}" already exists in registry pointing at ${existing.path}.\n` +
+        `  Use a different --name, or remove it first: pilot-manager remove ${name}`
+      );
+      process.exit(1);
+    }
+    console.log(`"${name}" already in registry (port ${existing.port}) — reusing.`);
+  } else {
+    try {
+      const options = {};
+      if (args.port) options.port = parseInt(args.port, 10);
+      const project = addProject(name, absPath, options);
+      console.log(`Added "${name}" (port ${project.port}) → ${absPath}`);
+    } catch (err) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  // Stage 2: register with server
+  console.log('\n--- Registering with server ---');
+  const project = getProject(name);
+  if (project?.auth_token && !args.force) {
+    console.log(`"${name}" already registered — reusing token. Use --force to re-register.`);
+  } else {
+    try {
+      const options = {};
+      if (args.server) options.server = args.server;
+      if (args.force) options.force = true;
+      const result = await registerProject(name, options);
+      console.log(`Registered "${name}" — token: ${result.auth_token?.slice(0, 8)}...`);
+    } catch (err) {
+      console.error(`Added OK, register failed: ${err.message}`);
+      console.error(`  Fix the issue, then retry: pilot-manager register ${name}`);
+      process.exit(1);
+    }
+  }
+
+  // Stage 3: install + load launchd service (bakes the token into the plist).
+  // If a service is already installed, regenerate the plist and reload so a
+  // freshly-saved token takes effect — a plain `launchctl load` would fail
+  // ("already loaded") and silently skip the reload.
+  console.log('\n--- Installing launchd service ---');
+  const alreadyInstalled = getServiceStatus(name) !== 'not installed';
+  try {
+    if (alreadyInstalled) {
+      restartService(name);
+      const pid = getServicePid(name);
+      console.log(`Reinstalled "${name}"${pid ? ` (PID ${pid})` : ''}`);
+    } else {
+      installService(name);
+      const pid = getServicePid(name);
+      console.log(`Installed "${name}"${pid ? ` (PID ${pid})` : ''}`);
+    }
+  } catch (err) {
+    console.error(`Registered OK, install failed: ${err.message}`);
+    console.error(`  Fix the issue, then retry: pilot-manager install ${name}`);
+    process.exit(1);
+  }
+
+  const finalPid = getServicePid(name);
+  console.log(`\nReady: "${name}"${finalPid ? ` (PID ${finalPid})` : ''}`);
+}
+
+async function cmdSetup(positionals, args) {
+  const target = positionals[0];
+  if (!target) {
+    console.error('Error: a path is required. Usage:\n' +
+      '  pilot-manager setup <path> --name X   (one project)\n' +
+      '  pilot-manager setup <parent-dir>      (scan all subdirs)');
+    process.exit(1);
+  }
+
+  // Init server config if provided (shared by both modes)
   const config = loadConfig();
   if (args.server) {
     config.server_url = args.server;
@@ -444,7 +525,13 @@ async function cmdSetup(positionals, args) {
   }
   ensureConfigDir();
 
-  // Step 2: Scan
+  // Single-project mode: --name signals "this path IS the project"
+  if (args.name) {
+    await setupSingleProject(target, args.name, args);
+    return;
+  }
+
+  // Bulk mode: scan the parent dir for projects (existing behavior)
   console.log('--- Scanning for projects ---');
   await cmdScan(positionals, { ...args, yes: args.yes });
 

--- a/src/launchd.js
+++ b/src/launchd.js
@@ -203,6 +203,19 @@ export function getServiceStatus(name) {
   return 'not installed';
 }
 
+// Decide what to do with a launchd service after its registration token changed,
+// given the service's current status. Pure (no launchctl, no fs) so the branch
+// logic is unit-testable in isolation:
+//   'not installed' → skip: nothing to reload; the token bakes in at first install.
+//   'installed' / 'running' → reinstall: regenerate the plist and reload so the
+//                             running daemon picks up the new token.
+export function planServiceRefresh(status) {
+  if (status === 'not installed') {
+    return { action: 'skip', installed: false };
+  }
+  return { action: 'reinstall', installed: true };
+}
+
 export function installService(name) {
   const project = getProject(name);
   if (!project) throw new Error(`Project "${name}" not found in registry`);

--- a/test/launchd.test.js
+++ b/test/launchd.test.js
@@ -12,7 +12,7 @@ fs.mkdirSync(path.join(TEST_DIR, '.config', 'claude-pilot-manager', 'env'), { re
 fs.mkdirSync(path.join(TEST_DIR, '.config', 'claude-pilot-manager', 'logs'), { recursive: true });
 fs.mkdirSync(path.join(TEST_DIR, 'Library', 'LaunchAgents'), { recursive: true });
 
-const { generatePlist, plistPath, resolveNodeBinary } = await import('../src/launchd.js');
+const { generatePlist, plistPath, resolveNodeBinary, planServiceRefresh } = await import('../src/launchd.js');
 const { saveConfig } = await import('../src/config.js');
 const { addProject } = await import('../src/registry.js');
 
@@ -96,6 +96,26 @@ describe('Plist Generation', () => {
     }
 
     assert.ok(plist.includes('<false/>'));
+  });
+});
+
+describe('planServiceRefresh (token-changed decision)', () => {
+  it('skips refresh when no service is installed', () => {
+    const plan = planServiceRefresh('not installed');
+    assert.equal(plan.action, 'skip');
+    assert.equal(plan.installed, false);
+  });
+
+  it('reinstalls when the service is installed but not running', () => {
+    const plan = planServiceRefresh('installed');
+    assert.equal(plan.action, 'reinstall');
+    assert.equal(plan.installed, true);
+  });
+
+  it('reinstalls when the service is currently running', () => {
+    const plan = planServiceRefresh('running');
+    assert.equal(plan.action, 'reinstall');
+    assert.equal(plan.installed, true);
   });
 });
 


### PR DESCRIPTION
## What

Adds a single-project mode to `setup`: `pilot-manager setup <path> --name X [--port N] [--server URL]` runs add → register → install for exactly one project, stopping at the first failed stage and pointing at the staged command to retry. Bulk scan mode (`setup <parent-dir>`) is unchanged. Bumps version 0.1.2 → 0.2.0 (minor — now also carries the #7 fix below).

## Also closes #7

`register --force` updated `projects.yml` with the new token but left the installed plist untouched, so the running daemon kept a stale (revoked) token in its `EnvironmentVariables`. This applies the same rule at the `register` door that `setup` stage 3 already applied: after a successful (re-)registration saves a new token, if that project's service is installed, regenerate the plist and reload it.

The "token changed → refresh installed service" behavior is now one shared helper, `refreshServiceIfInstalled(name)`, called by `cmdRegister` (both the single-project and register-all paths) and by `setupSingleProject`'s already-installed path. The decidable branch (given a service status, refresh or skip) is factored into a pure `planServiceRefresh()` in `launchd.js` with unit tests. Only installed services are refreshed; when nothing is installed yet the token bakes in at first install. A refresh failure after a successful registration is reported with a `pilot-manager reinstall <name>` retry pointer rather than being surfaced as a registration failure. `npm test`: 26/26 pass.

Closes #7

## Provenance — why this is a draft

This code was **lifted verbatim from uncommitted work in the live worktree** (`~/aiteams/team2/pilot-manager`, sitting dirty on the PR #9 branch) so it wouldn't stay stranded there. Draft because:

- No tests yet for `setupSingleProject` (registry-reuse path, register-failure exit, reinstall-vs-install branch).
- The author may have intended further changes.

Also still in that worktree, deliberately NOT included here (publishing to a public repo is the owner's call): untracked `GETTING_STARTED.md` and `.claude/skills/`.

Once this merges (or is rejected), the live worktree's dirty `src/cli.js` can be discarded — it is byte-identical to this branch's version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Also closes #7

Second commit extracts the shared rule — "a freshly saved token must be re-baked into an installed service's plist" — into `refreshServiceIfInstalled()` (decision logic in pure, unit-tested `planServiceRefresh()`), and applies it at the `register` door (single and register-all), not just `setup` stage 3. Version goes to 0.2.0 per the repo's minor-bump-for-features convention.

Closes #7
