### PR TITLE
feat: pilot-manager seed + persist explicit --server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ pilot-manager setup ~/projects --server http://localhost:3000 --yes
 | `token <name> [--reveal]` | Show auth token |
 | `setup <dir> [--server URL] [--yes]` | Scan + register + install in one step |
 
+> An explicit `--server URL` on `register`, `setup`, or `seed` is persisted to
+> `config.yml` (`server_url`), so a later `install` bakes the right server into
+> the daemon's plist instead of the localhost default.
+
+### Seed
+
+| Command | Description |
+|---------|-------------|
+| `seed <target-root> [--server URL]` | Download + install the Command Center seed vault |
+
 ### Other
 
 | Command | Description |
@@ -109,6 +119,27 @@ projects:
     extra_env:
       CUSTOM_VAR: value
 ```
+
+## Seeding a Command Center vault
+
+`seed` downloads the packaged "Command Center" vault that the FlightDeck server
+ships and installs it onto this machine:
+
+```bash
+pilot-manager seed ~/projects/radnine --server http://localhost:3000
+# → ~/projects/radnine/command-center/
+```
+
+It fetches `<server>/seed/command-center.tar.gz`, extracts and verifies it in a
+staging area, then moves it into `<target-root>/command-center`. The delivery is
+**refuse-don't-clobber** (it aborts if `<target-root>/command-center` already
+exists) and **atomic** (a corrupt download or an invalid vault leaves the target
+untouched — nothing is half-written). On success it prints the personas found
+and the suggested follow-up: `pilot-manager add <target-root>/command-center`.
+
+Extraction shells out to `tar`, so `seed` is macOS-only like the rest of
+pilot-manager. If the server returns 404, it hasn't packaged a seed yet (or is
+too old to ship one).
 
 ## Re-registering Daemons
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,8 @@ import path from 'node:path';
 import fs from 'node:fs';
 import readline from 'node:readline';
 import { execSync } from 'node:child_process';
-import { loadConfig, saveConfig } from './config.js';
+import { loadConfig, saveConfig, persistServerUrl } from './config.js';
+import { seedCommandCenter } from './seed.js';
 import { addProject, removeProject, listProjects, getProject } from './registry.js';
 import { ensureConfigDir, LOGS_DIR } from './paths.js';
 import {
@@ -47,6 +48,9 @@ Registration Commands:
   token <name> [--reveal]        Show auth token for a project
   setup <path> --name X [--port N] [--server URL]  Add + register + install one project
   setup <parent-dir> [--server URL] [--yes]        Scan + register + install all found
+
+Seed:
+  seed <target-root> [--server URL]  Download + install the Command Center seed vault
 
 Other:
   upgrade [--version X]          Upgrade daemon to latest (or specified) version
@@ -383,7 +387,15 @@ function refreshServiceIfInstalled(name) {
 
 async function cmdRegister(positionals, args) {
   const options = {};
-  if (args.server) options.server = args.server;
+  if (args.server) {
+    options.server = args.server;
+    // Persist the explicit server so a later `install` bakes it into the
+    // daemon's plist — otherwise the URL was used for this call only and the
+    // installed service kept pointing at the config default.
+    if (persistServerUrl(args.server)) {
+      console.log(`server_url saved to config (${args.server}).`);
+    }
+  }
   if (args.force) options.force = true;
 
   if (positionals.length > 0) {
@@ -583,6 +595,33 @@ async function cmdSetup(positionals, args) {
   cmdInstall([]);
 }
 
+async function cmdSeed(positionals, args) {
+  const targetRoot = positionals[0];
+  if (!targetRoot) {
+    console.error('Error: a target root is required. Usage: pilot-manager seed <target-root> [--server URL]');
+    process.exit(1);
+  }
+
+  // Same server precedence as register: --server flag, else config default.
+  const config = loadConfig();
+  const serverUrl = args.server || config.server_url;
+
+  try {
+    const { dest, personas } = await seedCommandCenter(targetRoot, serverUrl);
+    // Persist the server only after a successful delivery. seed is atomic —
+    // a bad target, unreachable server, or 404 must not mutate config.
+    if (args.server && persistServerUrl(args.server)) {
+      console.log(`server_url saved to config (${args.server}).`);
+    }
+    console.log(`\nSeeded Command Center vault → ${dest}`);
+    console.log(`Personas: ${personas.join(', ')}`);
+    console.log(`\nNext: pilot-manager add ${dest}`);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
 function cmdUpgrade(args) {
   const currentVersion = getInstalledDaemonVersion();
   if (!currentVersion) {
@@ -746,6 +785,9 @@ export async function run(argv) {
       break;
     case 'setup':
       await cmdSetup(parsed.positionals, parsed.values);
+      break;
+    case 'seed':
+      await cmdSeed(parsed.positionals, parsed.values);
       break;
     case 'upgrade':
       cmdUpgrade(parsed.values);

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,19 @@ export function saveConfig(config) {
   fs.renameSync(tmp, CONFIG_FILE);
 }
 
+// Persist an explicitly-chosen server URL so a later `install` bakes the right
+// CLAUDE_RAILS_URL into the daemon's plist. Without this, `register --server X`
+// used X only for the one API call while config kept the default localhost, so
+// the installed daemon pointed at the wrong server. Returns true if the file
+// changed (nothing to write when the URL already matches).
+export function persistServerUrl(url) {
+  const config = loadConfig();
+  if (config.server_url === url) return false;
+  config.server_url = url;
+  saveConfig(config);
+  return true;
+}
+
 function parseEnvFile(filePath) {
   if (!fs.existsSync(filePath)) return {};
   const lines = fs.readFileSync(filePath, 'utf8').split('\n');

--- a/src/seed.js
+++ b/src/seed.js
@@ -1,0 +1,181 @@
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { loadConfig } from './config.js';
+
+// Downloads the packaged "Command Center" seed vault from the FlightDeck server
+// and installs it onto this machine. The delivery is staged and atomic: nothing
+// touches the target until a downloaded archive has been extracted and verified
+// in a temp area, so a corrupt download or a broken vault leaves the target
+// exactly as it was.
+//
+// Platform note: extraction shells out to `tar -xzf`, so this is macOS-only
+// (the rest of pilot-manager is already macOS-only via launchd). BSD tar
+// preserves symlinks on extraction, which the persona files depend on.
+
+const SEED_PATH = '/seed/command-center.tar.gz';
+const VAULT_DIRNAME = 'command-center';
+
+// lstat (not stat) so a symlink — even a dangling one — counts as "exists".
+function pathExists(p) {
+  try {
+    fs.lstatSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function safeText(response) {
+  try {
+    return (await response.text()).trim();
+  } catch {
+    return '';
+  }
+}
+
+// Fetch the seed tarball as a Buffer. Mirrors registrar.js's friendly-error
+// vocabulary: ECONNREFUSED → "Cannot reach server"; 404 → "no packaged seed";
+// any other non-2xx → status + body.
+export async function fetchSeedTarball(serverUrl) {
+  const url = `${serverUrl}${SEED_PATH}`;
+
+  let response;
+  try {
+    response = await fetch(url);
+  } catch (err) {
+    if (err.cause?.code === 'ECONNREFUSED' || err.message.includes('fetch failed')) {
+      throw new Error(`Cannot reach server at ${serverUrl}. Is it running?`);
+    }
+    throw err;
+  }
+
+  if (response.status === 404) {
+    throw new Error(
+      `Server at ${serverUrl} has not packaged a seed vault (404 at ${SEED_PATH}).\n` +
+      `  The FlightDeck server may be too old to ship one, or the seed hasn't been built yet.`
+    );
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    const body = await safeText(response);
+    throw new Error(`Seed download failed (${response.status})${body ? `: ${body}` : ''}`);
+  }
+
+  return Buffer.from(await response.arrayBuffer());
+}
+
+// An archive may wrap the vault in a top-level `command-center/` directory or
+// place the vault contents at its root. Support both; the marker is INDEX.md.
+function resolveVaultRoot(extractDir) {
+  const wrapped = path.join(extractDir, VAULT_DIRNAME);
+  if (fs.existsSync(path.join(wrapped, 'INDEX.md'))) return wrapped;
+  if (fs.existsSync(path.join(extractDir, 'INDEX.md'))) return extractDir;
+  throw new Error(
+    'Seed archive has no INDEX.md at its root — it does not look like a Command Center vault.'
+  );
+}
+
+// Confirm the extracted tree is a real vault before we move it into place:
+// INDEX.md present, and every persona under .claude/personas/ resolves to an
+// existing file *within* the vault tree (a downloaded symlink must not point
+// outside it). Returns the sorted persona names for the success report.
+export function verifyVault(vaultRoot) {
+  if (!fs.existsSync(path.join(vaultRoot, 'INDEX.md'))) {
+    throw new Error('Seed archive is missing INDEX.md — it does not look like a Command Center vault.');
+  }
+
+  const personasDir = path.join(vaultRoot, '.claude', 'personas');
+  if (!pathExists(personasDir) || !fs.statSync(personasDir).isDirectory()) {
+    throw new Error('Seed archive is missing .claude/personas/ — it does not look like a Command Center vault.');
+  }
+
+  const entries = fs.readdirSync(personasDir).filter(f => f.endsWith('.md'));
+  if (entries.length === 0) {
+    throw new Error('Seed archive has no personas in .claude/personas/.');
+  }
+
+  const realRoot = fs.realpathSync(vaultRoot);
+  const personas = [];
+  for (const entry of entries) {
+    const linkPath = path.join(personasDir, entry);
+
+    let resolved;
+    try {
+      resolved = fs.realpathSync(linkPath);
+    } catch {
+      throw new Error(`Persona "${entry}" does not resolve — its symlink target is missing.`);
+    }
+
+    const rel = path.relative(realRoot, resolved);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error(`Persona "${entry}" escapes the vault tree (resolves to ${resolved}).`);
+    }
+
+    personas.push(path.basename(entry, '.md'));
+  }
+
+  return personas.sort();
+}
+
+// Write the tarball to a temp file, extract it, resolve + verify the vault root.
+// Throws (with the temp area handed back for the caller to clean up) on any
+// failure. Never writes outside `stageDir`.
+function extractAndVerify(tarball, stageDir) {
+  const tarPath = path.join(stageDir, 'command-center.tar.gz');
+  fs.writeFileSync(tarPath, tarball);
+
+  const extractDir = path.join(stageDir, 'extracted');
+  fs.mkdirSync(extractDir, { recursive: true });
+
+  try {
+    execSync(`tar -xzf "${tarPath}" -C "${extractDir}"`, { stdio: ['ignore', 'ignore', 'pipe'] });
+  } catch (err) {
+    const detail = err.stderr?.toString().trim() || err.message;
+    throw new Error(`Could not extract seed archive (is it a valid .tar.gz?): ${detail}`);
+  }
+
+  const vaultRoot = resolveVaultRoot(extractDir);
+  const personas = verifyVault(vaultRoot);
+  return { vaultRoot, personas };
+}
+
+// Orchestrate the whole seed: validate the target, refuse to clobber, download,
+// stage + verify, then atomically move into place. `serverUrl` precedence is the
+// caller's concern (same as register: --server flag else config.server_url).
+export async function seedCommandCenter(targetRoot, serverUrl) {
+  const absRoot = path.resolve(targetRoot);
+  if (!fs.existsSync(absRoot) || !fs.statSync(absRoot).isDirectory()) {
+    throw new Error(`Target root "${absRoot}" is not an existing directory.`);
+  }
+
+  const dest = path.join(absRoot, VAULT_DIRNAME);
+  if (pathExists(dest)) {
+    throw new Error(`Refusing to overwrite existing path "${dest}". Move or remove it, then retry.`);
+  }
+
+  const tarball = await fetchSeedTarball(serverUrl);
+
+  // Stage under the target root (not os.tmpdir) so the final move is an atomic,
+  // same-filesystem rename rather than a cross-device copy that could fail
+  // half-written. mkdtemp gives us a collision-free hidden dir alongside dest.
+  const stageDir = fs.mkdtempSync(path.join(absRoot, '.pilot-seed-'));
+  try {
+    const { vaultRoot, personas } = extractAndVerify(tarball, stageDir);
+
+    // Re-check right before the move: the window since the first check is where
+    // a racing writer could have created dest.
+    if (pathExists(dest)) {
+      throw new Error(`Refusing to overwrite existing path "${dest}" (it appeared during download).`);
+    }
+
+    fs.renameSync(vaultRoot, dest);
+    return { dest, personas };
+  } finally {
+    // Success or failure, the staging dir is disposable. On success the vault
+    // has already been renamed out of it; on failure the target was never
+    // touched. force:true tolerates the "already moved" case.
+    fs.rmSync(stageDir, { recursive: true, force: true });
+  }
+}

--- a/test/seed.test.js
+++ b/test/seed.test.js
@@ -1,0 +1,301 @@
+import { describe, it, beforeEach, afterEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+
+// Isolate config/registry under a temp HOME (same approach as registrar.test.js)
+// so loadConfig()/persistServerUrl() read defaults, not the real machine.
+const TEST_DIR = path.join(os.tmpdir(), `pilot-manager-seed-test-${process.pid}`);
+const origHome = process.env.HOME;
+process.env.HOME = TEST_DIR;
+fs.mkdirSync(path.join(TEST_DIR, '.config', 'claude-pilot-manager'), { recursive: true });
+
+const { fetchSeedTarball, seedCommandCenter, verifyVault } = await import('../src/seed.js');
+const { loadConfig, persistServerUrl } = await import('../src/config.js');
+const { addProject } = await import('../src/registry.js');
+const { run } = await import('../src/cli.js');
+
+const PERSONAS = ['optimus-prime', 'indiana-jones', 'sherlock-holmes'];
+
+// Build a Command Center vault fixture on disk, tar+gzip it, and return the
+// archive bytes as an ArrayBuffer (what a real fetch().arrayBuffer() yields).
+// The three personas are symlinks into personas/<name>/<name>.md so the tests
+// can prove symlinks survive the tar round-trip. Options let a test corrupt one
+// symlink (breakSymlink) or point it outside the tree (escapeSymlink).
+function buildVaultTarball({ wrap = true, breakSymlink = false, escapeSymlink = false } = {}) {
+  const src = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-seed-src-'));
+  const vault = wrap ? path.join(src, 'command-center') : src;
+  fs.mkdirSync(path.join(vault, '.claude', 'personas'), { recursive: true });
+  fs.writeFileSync(path.join(vault, 'INDEX.md'), '# Command Center\n');
+
+  PERSONAS.forEach((name, i) => {
+    const realDir = path.join(vault, 'personas', name);
+    fs.mkdirSync(realDir, { recursive: true });
+    fs.writeFileSync(path.join(realDir, `${name}.md`), `# ${name}\n`);
+
+    let target;
+    if (escapeSymlink && i === 0) {
+      target = '/etc/hosts'; // absolute → escapes the vault tree
+    } else if (breakSymlink && i === 0) {
+      target = path.join('..', '..', 'personas', name, 'missing.md');
+    } else {
+      target = path.join('..', '..', 'personas', name, `${name}.md`);
+    }
+    fs.symlinkSync(target, path.join(vault, '.claude', 'personas', `${name}.md`));
+  });
+
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-seed-tar-'));
+  const tarPath = path.join(outDir, 'seed.tar.gz');
+  execSync(`tar -czf "${tarPath}" -C "${src}" "${wrap ? 'command-center' : '.'}"`);
+  const buf = fs.readFileSync(tarPath);
+  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+
+  fs.rmSync(src, { recursive: true, force: true });
+  fs.rmSync(outDir, { recursive: true, force: true });
+  return ab;
+}
+
+// Install a fake global.fetch for the duration of one test.
+function mockFetch(fn) {
+  global.fetch = fn;
+}
+
+// Count leftover staging dirs so tests can assert "no partial writes".
+function stagingDirs(root) {
+  return fs.readdirSync(root).filter(n => n.startsWith('.pilot-seed-'));
+}
+
+const realFetch = global.fetch;
+let targetRoot;
+
+beforeEach(() => {
+  targetRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-seed-target-'));
+  const configFile = path.join(TEST_DIR, '.config', 'claude-pilot-manager', 'config.yml');
+  const projectsFile = path.join(TEST_DIR, '.config', 'claude-pilot-manager', 'projects.yml');
+  if (fs.existsSync(configFile)) fs.unlinkSync(configFile);
+  if (fs.existsSync(projectsFile)) fs.unlinkSync(projectsFile);
+});
+
+afterEach(() => {
+  global.fetch = realFetch;
+  fs.rmSync(targetRoot, { recursive: true, force: true });
+});
+
+after(() => {
+  process.env.HOME = origHome;
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('fetchSeedTarball error vocabulary', () => {
+  it('explains a 404 as "server has not packaged a seed"', async () => {
+    mockFetch(async () => ({ status: 404, text: async () => 'Not Found' }));
+    await assert.rejects(
+      fetchSeedTarball('http://localhost:3000'),
+      /has not packaged a seed vault/
+    );
+  });
+
+  it('translates ECONNREFUSED into "Cannot reach server"', async () => {
+    mockFetch(async () => {
+      const err = new Error('fetch failed');
+      err.cause = { code: 'ECONNREFUSED' };
+      throw err;
+    });
+    await assert.rejects(
+      fetchSeedTarball('http://localhost:9999'),
+      /Cannot reach server at http:\/\/localhost:9999/
+    );
+  });
+
+  it('reports status + body on other non-2xx responses', async () => {
+    mockFetch(async () => ({ status: 500, text: async () => 'boom' }));
+    await assert.rejects(
+      fetchSeedTarball('http://localhost:3000'),
+      /Seed download failed \(500\): boom/
+    );
+  });
+});
+
+describe('verifyVault', () => {
+  it('rejects a symlink that resolves outside the vault tree', () => {
+    // Extract a fixture whose first persona escapes to /etc/hosts, then verify.
+    const ab = buildVaultTarball({ escapeSymlink: true });
+    const work = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-verify-'));
+    fs.writeFileSync(path.join(work, 's.tar.gz'), Buffer.from(ab));
+    execSync(`tar -xzf "${path.join(work, 's.tar.gz')}" -C "${work}"`);
+    try {
+      assert.throws(() => verifyVault(path.join(work, 'command-center')), /escapes the vault tree/);
+    } finally {
+      fs.rmSync(work, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('seedCommandCenter — happy path', () => {
+  it('lands the vault, keeps persona symlinks intact, and reports personas', async () => {
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => buildVaultTarball() }));
+
+    const { dest, personas } = await seedCommandCenter(targetRoot, 'http://localhost:3000');
+
+    assert.equal(dest, path.join(targetRoot, 'command-center'));
+    assert.deepEqual(personas, [...PERSONAS].sort());
+    assert.ok(fs.existsSync(path.join(dest, 'INDEX.md')));
+
+    // Symlinks survived the tar round-trip AND still resolve to real files.
+    for (const name of PERSONAS) {
+      const link = path.join(dest, '.claude', 'personas', `${name}.md`);
+      assert.ok(fs.lstatSync(link).isSymbolicLink(), `${name} should still be a symlink`);
+      const resolved = fs.realpathSync(link);
+      assert.ok(resolved.startsWith(fs.realpathSync(dest)), `${name} should resolve within the vault`);
+      assert.equal(fs.readFileSync(resolved, 'utf8'), `# ${name}\n`);
+    }
+
+    // Staging dir was cleaned up.
+    assert.deepEqual(stagingDirs(targetRoot), []);
+  });
+
+  it('accepts an archive whose vault contents sit at the root (no wrapper dir)', async () => {
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => buildVaultTarball({ wrap: false }) }));
+    const { dest } = await seedCommandCenter(targetRoot, 'http://localhost:3000');
+    assert.ok(fs.existsSync(path.join(dest, 'INDEX.md')));
+    assert.deepEqual(stagingDirs(targetRoot), []);
+  });
+});
+
+describe('seedCommandCenter — refuse to clobber', () => {
+  it('aborts before any download when the target already exists, leaving it untouched', async () => {
+    const dest = path.join(targetRoot, 'command-center');
+    fs.mkdirSync(dest);
+    fs.writeFileSync(path.join(dest, 'sentinel.txt'), 'do not touch');
+
+    let fetched = false;
+    mockFetch(async () => { fetched = true; return { status: 200, arrayBuffer: async () => new ArrayBuffer(0) }; });
+
+    await assert.rejects(
+      seedCommandCenter(targetRoot, 'http://localhost:3000'),
+      /Refusing to overwrite existing path/
+    );
+
+    assert.equal(fetched, false, 'must not download when refusing to clobber');
+    assert.equal(fs.readFileSync(path.join(dest, 'sentinel.txt'), 'utf8'), 'do not touch');
+    assert.deepEqual(stagingDirs(targetRoot), []);
+  });
+
+  it('refuses when the target is a symlink, not just a real dir', async () => {
+    const dest = path.join(targetRoot, 'command-center');
+    fs.symlinkSync('/tmp', dest);
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => buildVaultTarball() }));
+    await assert.rejects(seedCommandCenter(targetRoot, 'http://localhost:3000'), /Refusing to overwrite/);
+    assert.deepEqual(stagingDirs(targetRoot), []);
+  });
+});
+
+describe('seedCommandCenter — atomicity', () => {
+  it('leaves the target untouched (and cleans staging) when the tarball is corrupt', async () => {
+    mockFetch(async () => ({
+      status: 200,
+      arrayBuffer: async () => new TextEncoder().encode('this is not a gzip stream').buffer,
+    }));
+
+    await assert.rejects(
+      seedCommandCenter(targetRoot, 'http://localhost:3000'),
+      /Could not extract seed archive/
+    );
+
+    assert.ok(!fs.existsSync(path.join(targetRoot, 'command-center')), 'no partial vault');
+    assert.deepEqual(stagingDirs(targetRoot), [], 'staging dir cleaned up');
+  });
+
+  it('rejects a valid archive that is not a vault (missing INDEX.md), untouched target', async () => {
+    // A tarball of an empty dir → extracts fine, but fails verification.
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-empty-'));
+    fs.mkdirSync(path.join(src, 'command-center'));
+    fs.writeFileSync(path.join(src, 'command-center', 'README.md'), 'no index here\n');
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-empty-tar-'));
+    execSync(`tar -czf "${path.join(outDir, 's.tar.gz')}" -C "${src}" command-center`);
+    const buf = fs.readFileSync(path.join(outDir, 's.tar.gz'));
+    const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    fs.rmSync(src, { recursive: true, force: true });
+    fs.rmSync(outDir, { recursive: true, force: true });
+
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => ab }));
+    await assert.rejects(seedCommandCenter(targetRoot, 'http://localhost:3000'), /INDEX\.md/);
+    assert.ok(!fs.existsSync(path.join(targetRoot, 'command-center')));
+    assert.deepEqual(stagingDirs(targetRoot), []);
+  });
+
+  it('rejects a vault whose persona symlink is broken', async () => {
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => buildVaultTarball({ breakSymlink: true }) }));
+    await assert.rejects(seedCommandCenter(targetRoot, 'http://localhost:3000'), /does not resolve/);
+    assert.ok(!fs.existsSync(path.join(targetRoot, 'command-center')));
+    assert.deepEqual(stagingDirs(targetRoot), []);
+  });
+});
+
+describe('seedCommandCenter — target validation', () => {
+  it('rejects a target root that does not exist', async () => {
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => buildVaultTarball() }));
+    await assert.rejects(
+      seedCommandCenter(path.join(targetRoot, 'nope'), 'http://localhost:3000'),
+      /is not an existing directory/
+    );
+  });
+});
+
+describe('persistServerUrl (register/seed --server bug fix)', () => {
+  it('writes config when the URL differs and returns true', () => {
+    assert.equal(loadConfig().server_url, 'http://localhost:3000');
+    assert.equal(persistServerUrl('http://real-server:3000'), true);
+    assert.equal(loadConfig().server_url, 'http://real-server:3000');
+  });
+
+  it('is a no-op (returns false) when the URL already matches', () => {
+    persistServerUrl('http://real-server:3000');
+    assert.equal(persistServerUrl('http://real-server:3000'), false);
+  });
+});
+
+describe('CLI persists --server', () => {
+  it('register --server saves server_url to config (was used for the call only)', async () => {
+    const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-proj-'));
+    addProject('demo', proj);
+    // Confirm a never-configured machine starts at the localhost default.
+    assert.equal(loadConfig().server_url, 'http://localhost:3000');
+
+    mockFetch(async () => ({
+      status: 201,
+      json: async () => ({ pilot: { pilot_id: 'p1' }, authentication: { api_key: 'tok_abc' } }),
+    }));
+
+    await run(['register', 'demo', '--server', 'http://real-server:3000']);
+
+    assert.equal(loadConfig().server_url, 'http://real-server:3000');
+    fs.rmSync(proj, { recursive: true, force: true });
+  });
+
+  it('seed --server saves server_url to config and delivers the vault', async () => {
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => buildVaultTarball() }));
+    await run(['seed', targetRoot, '--server', 'http://real-server:3000']);
+
+    assert.equal(loadConfig().server_url, 'http://real-server:3000');
+    assert.ok(fs.existsSync(path.join(targetRoot, 'command-center', 'INDEX.md')));
+  });
+
+  it('seed does NOT persist --server when the seed fails (atomic: no config mutation)', async () => {
+    // A failing seed (bad target root) must leave config at its default — the
+    // --server is only remembered once a vault has actually been delivered.
+    const before = loadConfig().server_url;
+    mockFetch(async () => ({ status: 200, arrayBuffer: async () => buildVaultTarball() }));
+
+    const realExit = process.exit;
+    process.exit = () => { throw new Error('exit'); }; // seed calls process.exit(1) on failure
+    try {
+      await run(['seed', path.join(targetRoot, 'missing'), '--server', 'http://should-not-persist:3000']);
+    } catch { /* expected: our exit stub throws */ }
+    finally { process.exit = realExit; }
+
+    assert.equal(loadConfig().server_url, before);
+  });
+});


### PR DESCRIPTION
## Summary

Wave-2 "Seed Vault" leg for the pilot-manager CLI: a new `seed` subcommand plus a `--server` persistence bug fix.

### Task 1 — `pilot-manager seed <target-root> [--server URL]`
Downloads the packaged Command Center vault from the FlightDeck server and installs it at `<target-root>/command-center`.

- **Server precedence**: `--server` flag, else `config.server_url` (same as `register`).
- **Fetch**: native `fetch` of `<server>/seed/command-center.tar.gz` → `arrayBuffer` → temp file. Reuses `registrar.js`'s friendly errors — `ECONNREFUSED` → "Cannot reach server", 404 → "server has not packaged a seed", other non-2xx → status + body.
- **Refuse-don't-clobber**: aborts (before any download) if `<target-root>/command-center` exists as any file/dir/symlink; also validates the target root is a directory.
- **Atomic delivery**: extracts + verifies in a staging dir *under the target root* (so the final move is an atomic, same-filesystem rename, not a cross-device copy), then renames into place. Any failure cleans the staging dir and leaves the target untouched.
- **Verification**: `INDEX.md` present and every `.claude/personas/*.md` symlink resolves to a real file **inside** the vault tree (rejects broken links and links escaping the tree).
- **Success output**: where it landed, the personas found, and the suggested `pilot-manager add <target-root>/command-center`.
- **Platform**: macOS-only (shells out to `tar -xzf`), documented in code + README.

### Task 2 — persist explicit `--server`
`register --server URL` used the URL for the API call but never wrote it to `config.yml`, so a later `install` baked the localhost default into the daemon plist (wrong server on a never-configured machine). New `config.persistServerUrl()` writes it (announced as "server_url saved to config") on `register`, and on a **successful** `seed` (seed is atomic — a failed seed does not mutate config).

## Command surface
```
Seed:
  seed <target-root> [--server URL]  Download + install the Command Center seed vault
```

## Tests
`test/seed.test.js` builds fixture tarballs in-process (no live server) and covers: refuse-don't-clobber (incl. symlink target), atomicity on corrupt / non-vault / broken-symlink archives, symlink survival through the tar round-trip, symlink-escape rejection, 404 / unreachable / non-2xx messages, and `--server` persistence (incl. no config mutation when a seed fails). Full suite: **43 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)