### PR TITLE
Leg 2: add managed core sync and safe maintenance command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Per-machine supervisor for `@radnine/claude-session-daemon` instances. Install i
 ## Quick Start
 
 ```bash
-# Install
-npm install -g @radnine/claude-pilot-manager
+# Install from the current pre-release GitHub source
+npm install -g git+https://github.com/radixhound/pilot-manager.git
 
 # Initialize (prompts for server URL and base port)
 pilot-manager init
@@ -73,6 +73,13 @@ pilot-manager setup ~/projects --server http://localhost:3000 --yes
 |---------|-------------|
 | `seed <target-root> [--server URL]` | Download + install the Command Center seed vault |
 
+### Managed FlightDeck maintenance
+
+| Command | Description |
+|---------|-------------|
+| `sync-core <command-center-path> [--server URL]` | Safely reconcile FlightDeck-managed core crew files |
+| `maintain <project-name> --command-center <path> [--server URL]` | Safely fast-forward a configured FlightDeck checkout, then synchronize core crew |
+
 ### Other
 
 | Command | Description |
@@ -88,6 +95,7 @@ All config lives in `~/.config/claude-pilot-manager/`:
 ~/.config/claude-pilot-manager/
 ├── config.yml        # Global settings
 ├── projects.yml      # Project registry
+├── managed-core/     # Hashed per-vault/per-server ownership state
 ├── env/
 │   ├── _default.env  # Shared env vars for all daemons
 │   └── <project>.env # Per-project env vars
@@ -140,6 +148,61 @@ and the suggested follow-up: `pilot-manager add <target-root>/command-center`.
 Extraction shells out to `tar`, so `seed` is macOS-only like the rest of
 pilot-manager. If the server returns 404, it hasn't packaged a seed yet (or is
 too old to ship one).
+
+## Synchronizing managed core crew
+
+`seed` remains create-only. Existing Command Center installations use the
+separate managed-core contract:
+
+```bash
+pilot-manager sync-core ~/projects/radnine/command-center \
+  --server http://localhost:3000
+```
+
+The command fetches FlightDeck's versioned ten-path allowlist, validates its
+UTF-8 content, SHA-256 values, entry versions, release digest, and contained
+symlinks, then preflights every destination before writing. Missing managed
+paths are installed. Identical content is adopted without a rewrite. A path
+that differs without an ownership record returns `NEEDS_DECISION`; a managed
+path changed or deleted after adoption returns `BLOCKED`. No user-created path
+outside the allowlist is changed.
+
+Ownership state lives under
+`~/.config/claude-pilot-manager/managed-core/`. File names and identity fields
+are hashes of the canonical vault path and server identity; state contains only
+the last managed release plus each path's kind and content hash. It stores no
+server URL, credential, token, or managed file content.
+
+For the bounded Flight Engineer maintenance operation, register the FlightDeck
+checkout in Pilot Manager and run:
+
+```bash
+pilot-manager maintain flight-deck \
+  --command-center ~/projects/radnine/command-center \
+  --server http://localhost:3000
+```
+
+`maintain` requires a clean Git working tree, an attached branch, a configured
+upstream, and no local-ahead or diverged state. It fetches that upstream and
+fast-forwards only when strictly behind, then runs the same managed-core sync.
+It never switches branches, rebases, resets, stashes, cleans, force-updates,
+runs migrations, installs dependencies, restarts services, or updates Pilot
+Manager itself.
+
+Both commands print one stable result token. `UPDATED` and `ALREADY_CURRENT`
+exit zero. `BLOCKED` exits 2 and `NEEDS_DECISION` exits 3 with concise evidence.
+
+## Updating Pilot Manager
+
+Pilot Manager is not published to the npm registry. During the current
+pre-release period, install or update it from GitHub:
+
+```bash
+npm install -g git+https://github.com/radixhound/pilot-manager.git
+```
+
+This documents the current delivery source; it is not a permanent release or
+publishing policy.
 
 ## Re-registering Daemons
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,8 @@ import readline from 'node:readline';
 import { execSync } from 'node:child_process';
 import { loadConfig, saveConfig, persistServerUrl } from './config.js';
 import { seedCommandCenter } from './seed.js';
+import { syncManagedCore } from './core-sync.js';
+import { maintainFlightDeck } from './maintenance.js';
 import { addProject, removeProject, listProjects, getProject } from './registry.js';
 import { ensureConfigDir, LOGS_DIR } from './paths.js';
 import {
@@ -51,6 +53,10 @@ Registration Commands:
 
 Seed:
   seed <target-root> [--server URL]  Download + install the Command Center seed vault
+
+Managed FlightDeck:
+  sync-core <command-center-path> [--server URL]  Safely synchronize managed core crew
+  maintain <project-name> --command-center PATH [--server URL]  Fast-forward FlightDeck + sync core crew
 
 Other:
   upgrade [--version X]          Upgrade daemon to latest (or specified) version
@@ -622,6 +628,49 @@ async function cmdSeed(positionals, args) {
   }
 }
 
+function emitManagedOutcome(managedResult) {
+  const lines = [managedResult.outcome, ...(managedResult.evidence || []).map(line => `- ${line}`)];
+  const refusal = managedResult.outcome === 'BLOCKED' || managedResult.outcome === 'NEEDS_DECISION';
+  const writer = refusal ? console.error : console.log;
+  for (const line of lines) writer(line);
+  if (managedResult.outcome === 'BLOCKED') process.exit(2);
+  if (managedResult.outcome === 'NEEDS_DECISION') process.exit(3);
+}
+
+async function cmdSyncCore(positionals, args) {
+  const commandCenterPath = positionals[0];
+  if (!commandCenterPath) {
+    emitManagedOutcome({
+      outcome: 'NEEDS_DECISION',
+      evidence: ['Command Center path is required. Usage: pilot-manager sync-core <command-center-path> [--server URL]'],
+    });
+    return;
+  }
+
+  const config = loadConfig();
+  const serverUrl = args.server || config.server_url;
+  emitManagedOutcome(await syncManagedCore(commandCenterPath, serverUrl));
+}
+
+async function cmdMaintain(positionals, args) {
+  const projectName = positionals[0];
+  const commandCenterPath = args['command-center'];
+  if (!projectName || !commandCenterPath) {
+    emitManagedOutcome({
+      outcome: 'NEEDS_DECISION',
+      evidence: [
+        'Configured FlightDeck project name and Command Center path are required. ' +
+        'Usage: pilot-manager maintain <project-name> --command-center <path> [--server URL]',
+      ],
+    });
+    return;
+  }
+
+  const config = loadConfig();
+  const serverUrl = args.server || config.server_url;
+  emitManagedOutcome(await maintainFlightDeck(projectName, commandCenterPath, serverUrl));
+}
+
 function cmdUpgrade(args) {
   const currentVersion = getInstalledDaemonVersion();
   if (!currentVersion) {
@@ -725,6 +774,7 @@ export async function run(argv) {
         stdout: { type: 'boolean', default: false },
         lines: { type: 'string' },
         version: { type: 'string' },
+        'command-center': { type: 'string' },
       },
       allowPositionals: true,
       strict: false,
@@ -788,6 +838,12 @@ export async function run(argv) {
       break;
     case 'seed':
       await cmdSeed(parsed.positionals, parsed.values);
+      break;
+    case 'sync-core':
+      await cmdSyncCore(parsed.positionals, parsed.values);
+      break;
+    case 'maintain':
+      await cmdMaintain(parsed.positionals, parsed.values);
       break;
     case 'upgrade':
       cmdUpgrade(parsed.values);

--- a/src/core-sync.js
+++ b/src/core-sync.js
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { TextDecoder } from 'node:util';
-import { MANAGED_CORE_STATE_DIR, ensureConfigDir } from './paths.js';
+import { CONFIG_DIR, MANAGED_CORE_STATE_DIR } from './paths.js';
 
 const MANIFEST_PATH = '/seed/core-crew/manifest.json';
 const STATE_SCHEMA_VERSION = 1;
@@ -195,6 +195,53 @@ function canonicalVaultPath(vaultPath) {
     throw new CoreSyncRefusal('BLOCKED', `Command Center path "${resolved}" is not a directory.`);
   }
   return fs.realpathSync(resolved);
+}
+
+const STATE_DIRECTORY_CHAIN = [
+  path.dirname(CONFIG_DIR),
+  CONFIG_DIR,
+  MANAGED_CORE_STATE_DIR,
+];
+
+function trustedStateDirectory({ create = false } = {}) {
+  let stateDirectoryStat;
+  for (const directory of STATE_DIRECTORY_CHAIN) {
+    let stat;
+    try {
+      stat = fs.lstatSync(directory);
+    } catch (error) {
+      if (error.code !== 'ENOENT' || !create) {
+        throw new CoreSyncRefusal('BLOCKED', 'Managed-core state directory cannot be trusted.');
+      }
+      try {
+        fs.mkdirSync(directory, { mode: 0o700 });
+        stat = fs.lstatSync(directory);
+      } catch {
+        throw new CoreSyncRefusal('BLOCKED', 'Managed-core state directory cannot be established safely.');
+      }
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        'Managed-core state directory or one of its config ancestors is not a real directory.',
+      );
+    }
+    if (directory === MANAGED_CORE_STATE_DIR) stateDirectoryStat = stat;
+  }
+
+  try {
+    return {
+      realpath: fs.realpathSync(MANAGED_CORE_STATE_DIR),
+      device: stateDirectoryStat.dev,
+      inode: stateDirectoryStat.ino,
+    };
+  } catch {
+    throw new CoreSyncRefusal('BLOCKED', 'Managed-core state directory cannot be resolved safely.');
+  }
+}
+
+function sameTrustedStateDirectory(left, right) {
+  return left.realpath === right.realpath && left.device === right.device && left.inode === right.inode;
 }
 
 export function managedCoreStatePath(vaultPath, serverUrl) {
@@ -475,16 +522,12 @@ function verifyApplied(canonicalVault, manifest) {
   }
 }
 
-function saveState(statePath, state, previousState) {
+function saveState(statePath, state, previousState, trustedStateRoot) {
   const serialized = `${JSON.stringify(state, null, 2)}\n`;
-  if (previousState && JSON.stringify(previousState) === JSON.stringify(state)) return;
-
-  ensureConfigDir();
-  fs.mkdirSync(MANAGED_CORE_STATE_DIR, { recursive: true, mode: 0o700 });
-  const stateDirectoryStat = fs.lstatSync(MANAGED_CORE_STATE_DIR);
-  if (stateDirectoryStat.isSymbolicLink() || !stateDirectoryStat.isDirectory()) {
-    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core state directory is not a regular directory.');
+  if (!sameTrustedStateDirectory(trustedStateDirectory(), trustedStateRoot)) {
+    throw new CoreSyncRefusal('BLOCKED', 'Managed-core state directory identity changed during synchronization.');
   }
+  if (previousState && JSON.stringify(previousState) === JSON.stringify(state)) return;
   const temporary = `${statePath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
   try {
     fs.writeFileSync(temporary, serialized, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
@@ -505,17 +548,24 @@ export async function syncManagedCore(vaultPath, serverUrl, options = {}) {
       server_identity: digestIdentity(serverIdentity),
     };
     const statePath = managedCoreStatePath(canonicalVault, serverIdentity);
+    const trustedStateRoot = trustedStateDirectory({ create: true });
     const state = loadState(statePath, identity);
     const { changes, snapshots } = preflight(canonicalVault, manifest, state);
 
     if (changes.length > 0) {
+      if (!sameTrustedStateDirectory(trustedStateDirectory(), trustedStateRoot)) {
+        throw new CoreSyncRefusal('BLOCKED', 'Managed-core state directory identity changed before staging.');
+      }
       stageDir = stageChanges(canonicalVault, changes);
+      if (!sameTrustedStateDirectory(trustedStateDirectory(), trustedStateRoot)) {
+        throw new CoreSyncRefusal('BLOCKED', 'Managed-core state directory identity changed before application.');
+      }
       applyChanges(canonicalVault, stageDir, changes, snapshots);
     }
     verifyApplied(canonicalVault, manifest);
 
     const nextState = stateFor(manifest, canonicalVault, serverIdentity);
-    saveState(statePath, nextState, state);
+    saveState(statePath, nextState, state, trustedStateRoot);
 
     if (changes.length > 0) {
       return {

--- a/src/core-sync.js
+++ b/src/core-sync.js
@@ -1,0 +1,542 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { TextDecoder } from 'node:util';
+import { MANAGED_CORE_STATE_DIR, ensureConfigDir } from './paths.js';
+
+const MANIFEST_PATH = '/seed/core-crew/manifest.json';
+const STATE_SCHEMA_VERSION = 1;
+const MAX_MANIFEST_BYTES = 2 * 1024 * 1024;
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+const VERSION_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+export const MANAGED_CORE_ENTRIES = Object.freeze([
+  { path: '.claude/personas/chief-of-staff.md', kind: 'symlink' },
+  { path: '.claude/personas/flight-engineer.md', kind: 'symlink' },
+  { path: '.claude/personas/persona-architect.md', kind: 'symlink' },
+  { path: '.claude/personas/quartermaster.md', kind: 'symlink' },
+  { path: '.claude/skills/flightdeck-managed-maintenance/SKILL.md', kind: 'file' },
+  { path: '.claude/skills/repository-onboarding/SKILL.md', kind: 'file' },
+  { path: 'agents/chief-of-staff.md', kind: 'file' },
+  { path: 'agents/flight-engineer.md', kind: 'file' },
+  { path: 'agents/persona-architect.md', kind: 'file' },
+  { path: 'agents/quartermaster.md', kind: 'file' },
+]);
+
+class CoreSyncRefusal extends Error {
+  constructor(outcome, message) {
+    super(message);
+    this.name = 'CoreSyncRefusal';
+    this.outcome = outcome;
+  }
+}
+
+function refusal(outcome, message) {
+  return { outcome, evidence: [message], changedPaths: [] };
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function digestIdentity(value) {
+  return `sha256:${sha256(Buffer.from(value, 'utf8'))}`;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireExactKeys(value, keys, label) {
+  if (!isPlainObject(value)) throw new CoreSyncRefusal('NEEDS_DECISION', `${label} must be an object.`);
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', `${label} has an unsupported schema.`);
+  }
+}
+
+function containsUnpairedSurrogate(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function assertUtf8String(value, label) {
+  if (typeof value !== 'string' || containsUnpairedSurrogate(value)) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', `${label} must contain valid UTF-8 text.`);
+  }
+}
+
+function safeManagedPath(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0') || value.includes('\\')) {
+    return false;
+  }
+  if (path.posix.isAbsolute(value) || path.posix.normalize(value) !== value) return false;
+  const components = value.split('/');
+  return components.every(component => component !== '' && component !== '.' && component !== '..');
+}
+
+function validateSymlinkTarget(entry) {
+  const target = entry.content;
+  if (target.length === 0 || target.includes('\0') || path.posix.isAbsolute(target)) {
+    throw new CoreSyncRefusal(
+      'NEEDS_DECISION',
+      `Managed symlink "${entry.path}" must have a non-empty relative target.`,
+    );
+  }
+
+  const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(entry.path), target));
+  if (resolved === '..' || resolved.startsWith('../') || path.posix.isAbsolute(resolved)) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', `Managed symlink "${entry.path}" escapes the vault.`);
+  }
+}
+
+export function validateCoreManifest(candidate) {
+  requireExactKeys(candidate, ['schema_version', 'release_version', 'entries'], 'Managed-core manifest');
+  if (candidate.schema_version !== 1) {
+    throw new CoreSyncRefusal(
+      'NEEDS_DECISION',
+      `Managed-core schema version ${String(candidate.schema_version)} is not supported.`,
+    );
+  }
+  if (!VERSION_PATTERN.test(candidate.release_version)) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core release version is invalid.');
+  }
+  if (!Array.isArray(candidate.entries)) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core entries must be an array.');
+  }
+
+  const paths = candidate.entries.map((entry, index) => {
+    requireExactKeys(entry, ['path', 'kind', 'version', 'sha256', 'content'], `Managed-core entry ${index + 1}`);
+    if (!safeManagedPath(entry.path)) {
+      throw new CoreSyncRefusal('NEEDS_DECISION', `Managed path at entry ${index + 1} is unsafe.`);
+    }
+    return entry.path;
+  });
+
+  if (new Set(paths).size !== paths.length) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed paths must be unique.');
+  }
+  const sortedPaths = [...paths].sort();
+  if (paths.some((managedPath, index) => managedPath !== sortedPaths[index])) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core entries must be sorted by path.');
+  }
+  const expectedPaths = MANAGED_CORE_ENTRIES.map(entry => entry.path);
+  if (paths.length !== expectedPaths.length || paths.some((managedPath, index) => managedPath !== expectedPaths[index])) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed paths do not match the schema version 1 allowlist.');
+  }
+
+  candidate.entries.forEach((entry, index) => {
+    const expected = MANAGED_CORE_ENTRIES[index];
+    if (entry.kind !== expected.kind || !['file', 'symlink'].includes(entry.kind)) {
+      throw new CoreSyncRefusal('NEEDS_DECISION', `Managed entry "${entry.path}" has an unsupported kind.`);
+    }
+    assertUtf8String(entry.content, `Managed entry "${entry.path}" content`);
+    if (!HASH_PATTERN.test(entry.sha256)) {
+      throw new CoreSyncRefusal('NEEDS_DECISION', `Managed entry "${entry.path}" has an invalid SHA-256.`);
+    }
+    const contentHash = sha256(Buffer.from(entry.content, 'utf8'));
+    if (entry.sha256 !== contentHash) {
+      throw new CoreSyncRefusal('NEEDS_DECISION', `Managed entry "${entry.path}" content hash does not match.`);
+    }
+    if (entry.version !== `sha256:${contentHash}`) {
+      throw new CoreSyncRefusal('NEEDS_DECISION', `Managed entry "${entry.path}" entry version does not match.`);
+    }
+    if (entry.kind === 'symlink') validateSymlinkTarget(entry);
+  });
+
+  const releaseMaterial = candidate.entries
+    .map(entry => `${entry.path}\0${entry.kind}\0${entry.sha256}\n`)
+    .join('');
+  const releaseVersion = `sha256:${sha256(Buffer.from(releaseMaterial, 'utf8'))}`;
+  if (candidate.release_version !== releaseVersion) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core release version does not match its entries.');
+  }
+
+  return candidate;
+}
+
+export function canonicalServerIdentity(serverUrl) {
+  let parsed;
+  try {
+    parsed = new URL(serverUrl);
+  } catch {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'FlightDeck server URL is invalid.');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new CoreSyncRefusal(
+      'NEEDS_DECISION',
+      'FlightDeck server URL must be HTTP(S) and must not contain credentials, query parameters, or a fragment.',
+    );
+  }
+  const pathname = parsed.pathname.replace(/\/+$/, '');
+  return `${parsed.origin}${pathname}`;
+}
+
+function canonicalVaultPath(vaultPath) {
+  const resolved = path.resolve(vaultPath);
+  let stat;
+  try {
+    stat = fs.statSync(resolved);
+  } catch {
+    throw new CoreSyncRefusal('BLOCKED', `Command Center path "${resolved}" is not available.`);
+  }
+  if (!stat.isDirectory()) {
+    throw new CoreSyncRefusal('BLOCKED', `Command Center path "${resolved}" is not a directory.`);
+  }
+  return fs.realpathSync(resolved);
+}
+
+export function managedCoreStatePath(vaultPath, serverUrl) {
+  const canonicalVault = canonicalVaultPath(vaultPath);
+  const serverIdentity = canonicalServerIdentity(serverUrl);
+  const key = sha256(Buffer.from(`${canonicalVault}\0${serverIdentity}`, 'utf8'));
+  return path.join(MANAGED_CORE_STATE_DIR, `${key}.json`);
+}
+
+export async function fetchCoreManifest(serverUrl, { fetchImpl = global.fetch } = {}) {
+  const serverIdentity = canonicalServerIdentity(serverUrl);
+  let response;
+  try {
+    response = await fetchImpl(`${serverIdentity}${MANIFEST_PATH}`);
+  } catch (error) {
+    if (error instanceof CoreSyncRefusal) throw error;
+    throw new CoreSyncRefusal('BLOCKED', 'Cannot reach the FlightDeck managed-core endpoint.');
+  }
+
+  if (!response || response.status < 200 || response.status >= 300) {
+    const status = response?.status ? ` (HTTP ${response.status})` : '';
+    throw new CoreSyncRefusal('BLOCKED', `FlightDeck managed-core endpoint is unavailable${status}.`);
+  }
+  const contentType = response.headers?.get?.('content-type');
+  if (contentType && !contentType.toLowerCase().startsWith('application/json')) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core response is not JSON.');
+  }
+
+  let bytes;
+  try {
+    bytes = Buffer.from(await response.arrayBuffer());
+  } catch {
+    throw new CoreSyncRefusal('BLOCKED', 'Could not read the managed-core response.');
+  }
+  if (bytes.length > MAX_MANIFEST_BYTES) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core response exceeds the supported size.');
+  }
+
+  let text;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core response is not valid UTF-8.');
+  }
+
+  let candidate;
+  try {
+    candidate = JSON.parse(text);
+  } catch {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core response is not valid JSON.');
+  }
+  return validateCoreManifest(candidate);
+}
+
+function stateFor(manifest, canonicalVault, serverIdentity) {
+  const entries = {};
+  for (const entry of manifest.entries) {
+    entries[entry.path] = { kind: entry.kind, sha256: entry.sha256 };
+  }
+  return {
+    schema_version: STATE_SCHEMA_VERSION,
+    vault_identity: digestIdentity(canonicalVault),
+    server_identity: digestIdentity(serverIdentity),
+    release_version: manifest.release_version,
+    entries,
+  };
+}
+
+function validateState(candidate, expectedIdentity) {
+  requireExactKeys(
+    candidate,
+    ['schema_version', 'vault_identity', 'server_identity', 'release_version', 'entries'],
+    'Managed-core ownership state',
+  );
+  if (candidate.schema_version !== STATE_SCHEMA_VERSION ||
+      candidate.vault_identity !== expectedIdentity.vault_identity ||
+      candidate.server_identity !== expectedIdentity.server_identity ||
+      !VERSION_PATTERN.test(candidate.release_version)) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core ownership state has an unsupported identity or version.');
+  }
+  requireExactKeys(candidate.entries, MANAGED_CORE_ENTRIES.map(entry => entry.path), 'Managed-core ownership entries');
+  for (const definition of MANAGED_CORE_ENTRIES) {
+    const entry = candidate.entries[definition.path];
+    requireExactKeys(entry, ['kind', 'sha256'], `Ownership entry "${definition.path}"`);
+    if (entry.kind !== definition.kind || !HASH_PATTERN.test(entry.sha256)) {
+      throw new CoreSyncRefusal('NEEDS_DECISION', `Ownership entry "${definition.path}" is invalid.`);
+    }
+  }
+  return candidate;
+}
+
+function loadState(statePath, expectedIdentity) {
+  let stat;
+  try {
+    stat = fs.lstatSync(statePath);
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw new CoreSyncRefusal('BLOCKED', 'Managed-core ownership state cannot be inspected.');
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core ownership state is not a regular file.');
+  }
+  try {
+    return validateState(JSON.parse(fs.readFileSync(statePath, 'utf8')), expectedIdentity);
+  } catch (error) {
+    if (error instanceof CoreSyncRefusal) throw error;
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core ownership state is invalid JSON.');
+  }
+}
+
+function destinationState(targetPath) {
+  let stat;
+  try {
+    stat = fs.lstatSync(targetPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') return { kind: 'missing', sha256: null };
+    throw new CoreSyncRefusal('BLOCKED', `Managed path "${targetPath}" cannot be inspected.`);
+  }
+
+  if (stat.isSymbolicLink()) {
+    return { kind: 'symlink', sha256: sha256(fs.readlinkSync(targetPath, { encoding: 'buffer' })) };
+  }
+  if (stat.isFile()) {
+    return { kind: 'file', sha256: sha256(fs.readFileSync(targetPath)) };
+  }
+  return { kind: 'other', sha256: null };
+}
+
+function sameDestination(left, right) {
+  return left.kind === right.kind && left.sha256 === right.sha256;
+}
+
+function inspectAncestors(canonicalVault, managedPath) {
+  const components = path.posix.dirname(managedPath).split('/').filter(component => component !== '.');
+  let current = canonicalVault;
+  for (const component of components) {
+    current = path.join(current, component);
+    let stat;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if (error.code === 'ENOENT') continue;
+      throw new CoreSyncRefusal('BLOCKED', `Managed parent for "${managedPath}" cannot be inspected.`);
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      return current;
+    }
+  }
+  return null;
+}
+
+function preflight(canonicalVault, manifest, state) {
+  const changes = [];
+  const snapshots = new Map();
+
+  for (const entry of manifest.entries) {
+    const unsafeParent = inspectAncestors(canonicalVault, entry.path);
+    if (unsafeParent) {
+      throw new CoreSyncRefusal(
+        state ? 'BLOCKED' : 'NEEDS_DECISION',
+        `Managed path "${entry.path}" has a symlink or non-directory parent; no content was changed.`,
+      );
+    }
+
+    const targetPath = path.join(canonicalVault, entry.path);
+    const current = destinationState(targetPath);
+    snapshots.set(entry.path, current);
+    const previous = state?.entries?.[entry.path];
+
+    if (current.kind === 'missing') {
+      if (previous) {
+        throw new CoreSyncRefusal(
+          'BLOCKED',
+          `Managed path "${entry.path}" was deleted after the last applied release; no content was changed.`,
+        );
+      }
+      changes.push(entry);
+      continue;
+    }
+
+    if (current.kind === entry.kind && current.sha256 === entry.sha256) continue;
+
+    if (!previous) {
+      throw new CoreSyncRefusal(
+        'NEEDS_DECISION',
+        `Existing path "${entry.path}" differs from FlightDeck content and has no ownership record; no content was changed.`,
+      );
+    }
+    if (previous.kind !== entry.kind) {
+      throw new CoreSyncRefusal(
+        'NEEDS_DECISION',
+        `Managed path "${entry.path}" has an ambiguous type transition; no content was changed.`,
+      );
+    }
+    if (current.kind !== previous.kind || current.sha256 !== previous.sha256) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        `Managed path "${entry.path}" was locally modified or changed type; no content was changed.`,
+      );
+    }
+    changes.push(entry);
+  }
+
+  return { changes, snapshots };
+}
+
+function stageChanges(canonicalVault, changes) {
+  const stageDir = fs.mkdtempSync(path.join(canonicalVault, '.pilot-core-'));
+  try {
+    for (const entry of changes) {
+      const stagedPath = path.join(stageDir, entry.path);
+      fs.mkdirSync(path.dirname(stagedPath), { recursive: true });
+      if (entry.kind === 'symlink') fs.symlinkSync(entry.content, stagedPath);
+      else fs.writeFileSync(stagedPath, Buffer.from(entry.content, 'utf8'), { mode: 0o644 });
+    }
+  } catch (error) {
+    fs.rmSync(stageDir, { recursive: true, force: true });
+    throw new CoreSyncRefusal('BLOCKED', 'Managed-core content could not be staged on the target filesystem.');
+  }
+  return stageDir;
+}
+
+function applyChanges(canonicalVault, stageDir, changes, snapshots) {
+  for (const entry of changes) {
+    const targetPath = path.join(canonicalVault, entry.path);
+    if (!sameDestination(destinationState(targetPath), snapshots.get(entry.path))) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        `Managed path "${entry.path}" changed during synchronization; no staged content was applied.`,
+      );
+    }
+  }
+
+  for (const entry of changes) {
+    const targetPath = path.join(canonicalVault, entry.path);
+    if (inspectAncestors(canonicalVault, entry.path)) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        `Managed parent for "${entry.path}" changed during synchronization; no staged content was applied.`,
+      );
+    }
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    if (inspectAncestors(canonicalVault, entry.path)) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        `Managed parent for "${entry.path}" became unsafe during synchronization; no staged content was applied.`,
+      );
+    }
+  }
+
+  for (const entry of changes) {
+    const targetPath = path.join(canonicalVault, entry.path);
+    if (inspectAncestors(canonicalVault, entry.path)) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        `Managed parent for "${entry.path}" changed during synchronization; reconciliation stopped.`,
+      );
+    }
+    if (!sameDestination(destinationState(targetPath), snapshots.get(entry.path))) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        `Managed path "${entry.path}" changed during synchronization; reconciliation stopped.`,
+      );
+    }
+    fs.renameSync(path.join(stageDir, entry.path), targetPath);
+  }
+}
+
+function verifyApplied(canonicalVault, manifest) {
+  for (const entry of manifest.entries) {
+    const current = destinationState(path.join(canonicalVault, entry.path));
+    if (current.kind !== entry.kind || current.sha256 !== entry.sha256) {
+      throw new CoreSyncRefusal(
+        'BLOCKED',
+        `Managed path "${entry.path}" could not be verified after application; ownership state was not advanced.`,
+      );
+    }
+  }
+}
+
+function saveState(statePath, state, previousState) {
+  const serialized = `${JSON.stringify(state, null, 2)}\n`;
+  if (previousState && JSON.stringify(previousState) === JSON.stringify(state)) return;
+
+  ensureConfigDir();
+  fs.mkdirSync(MANAGED_CORE_STATE_DIR, { recursive: true, mode: 0o700 });
+  const stateDirectoryStat = fs.lstatSync(MANAGED_CORE_STATE_DIR);
+  if (stateDirectoryStat.isSymbolicLink() || !stateDirectoryStat.isDirectory()) {
+    throw new CoreSyncRefusal('NEEDS_DECISION', 'Managed-core state directory is not a regular directory.');
+  }
+  const temporary = `${statePath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  try {
+    fs.writeFileSync(temporary, serialized, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    fs.renameSync(temporary, statePath);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+export async function syncManagedCore(vaultPath, serverUrl, options = {}) {
+  let stageDir;
+  try {
+    const canonicalVault = canonicalVaultPath(vaultPath);
+    const serverIdentity = canonicalServerIdentity(serverUrl);
+    const manifest = await fetchCoreManifest(serverIdentity, options);
+    const identity = {
+      vault_identity: digestIdentity(canonicalVault),
+      server_identity: digestIdentity(serverIdentity),
+    };
+    const statePath = managedCoreStatePath(canonicalVault, serverIdentity);
+    const state = loadState(statePath, identity);
+    const { changes, snapshots } = preflight(canonicalVault, manifest, state);
+
+    if (changes.length > 0) {
+      stageDir = stageChanges(canonicalVault, changes);
+      applyChanges(canonicalVault, stageDir, changes, snapshots);
+    }
+    verifyApplied(canonicalVault, manifest);
+
+    const nextState = stateFor(manifest, canonicalVault, serverIdentity);
+    saveState(statePath, nextState, state);
+
+    if (changes.length > 0) {
+      return {
+        outcome: 'UPDATED',
+        evidence: [
+          `Managed core release ${manifest.release_version} applied.`,
+          `${changes.length} managed path(s) installed or updated.`,
+        ],
+        changedPaths: changes.map(entry => entry.path),
+        releaseVersion: manifest.release_version,
+      };
+    }
+    return {
+      outcome: 'ALREADY_CURRENT',
+      evidence: [`Managed core release ${manifest.release_version} is already current.`],
+      changedPaths: [],
+      releaseVersion: manifest.release_version,
+    };
+  } catch (error) {
+    if (error instanceof CoreSyncRefusal) return refusal(error.outcome, error.message);
+    return refusal('BLOCKED', 'Managed-core synchronization failed before ownership state could be advanced.');
+  } finally {
+    if (stageDir) fs.rmSync(stageDir, { recursive: true, force: true });
+  }
+}

--- a/src/core-sync.js
+++ b/src/core-sync.js
@@ -60,6 +60,7 @@ function containsUnpairedSurrogate(value) {
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
     if (code >= 0xd800 && code <= 0xdbff) {
+      if (index + 1 >= value.length) return true;
       const next = value.charCodeAt(index + 1);
       if (next < 0xdc00 || next > 0xdfff) return true;
       index += 1;

--- a/src/maintenance.js
+++ b/src/maintenance.js
@@ -1,0 +1,227 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { getProject } from './registry.js';
+import { syncManagedCore } from './core-sync.js';
+
+const SUCCESS_OUTCOMES = new Set(['UPDATED', 'ALREADY_CURRENT']);
+const REFUSAL_OUTCOMES = new Set(['BLOCKED', 'NEEDS_DECISION']);
+
+const defaultGit = {
+  run(args, cwd) {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  },
+};
+
+function result(outcome, evidence, checkoutUpdated = false) {
+  return { outcome, evidence, checkoutUpdated };
+}
+
+function runGit(git, args, cwd, failureMessage) {
+  try {
+    return git.run(args, cwd).trim();
+  } catch {
+    const error = new Error(failureMessage);
+    error.isMaintenanceRefusal = true;
+    throw error;
+  }
+}
+
+function canonicalDirectory(directory) {
+  try {
+    if (!fs.statSync(directory).isDirectory()) return null;
+    return fs.realpathSync(directory);
+  } catch {
+    return null;
+  }
+}
+
+function parseAheadBehind(output) {
+  const match = output.match(/^(\d+)\s+(\d+)$/);
+  if (!match) return null;
+  return { ahead: Number(match[1]), behind: Number(match[2]) };
+}
+
+function inspectAndUpdateCheckout(projectPath, git) {
+  const canonicalProject = canonicalDirectory(path.resolve(projectPath));
+  if (!canonicalProject) {
+    return result('BLOCKED', ['Configured FlightDeck checkout is not an available directory.']);
+  }
+
+  let topLevel;
+  try {
+    topLevel = runGit(git, ['rev-parse', '--show-toplevel'], canonicalProject, 'Configured FlightDeck path is not a Git checkout.');
+  } catch (error) {
+    return result('BLOCKED', [error.message]);
+  }
+  const canonicalTopLevel = canonicalDirectory(topLevel);
+  if (!canonicalTopLevel) {
+    return result('BLOCKED', ['Configured FlightDeck Git root is not available.']);
+  }
+  if (canonicalTopLevel !== canonicalProject) {
+    return result(
+      'NEEDS_DECISION',
+      ['Configured FlightDeck project path is not the checkout root; target identity is ambiguous.'],
+    );
+  }
+
+  let status;
+  try {
+    status = runGit(
+      git,
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      canonicalProject,
+      'FlightDeck working-tree state could not be inspected.',
+    );
+  } catch (error) {
+    return result('BLOCKED', [error.message]);
+  }
+  if (status !== '') {
+    return result('BLOCKED', ['FlightDeck working tree is dirty; no Git update or core sync was attempted.']);
+  }
+
+  let branch;
+  try {
+    branch = runGit(
+      git,
+      ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+      canonicalProject,
+      'FlightDeck checkout is detached; an attached branch is required.',
+    );
+  } catch (error) {
+    return result('BLOCKED', [error.message]);
+  }
+
+  let fastForwardCompleted = false;
+  try {
+    runGit(
+      git,
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+      canonicalProject,
+      'FlightDeck branch has no configured upstream.',
+    );
+  } catch (error) {
+    return result('BLOCKED', [error.message]);
+  }
+
+  let remote;
+  try {
+    remote = runGit(
+      git,
+      ['config', '--get', `branch.${branch}.remote`],
+      canonicalProject,
+      'FlightDeck branch has no configured upstream remote.',
+    );
+  } catch (error) {
+    return result('BLOCKED', [error.message]);
+  }
+  if (!remote || remote.startsWith('-') || !/^[A-Za-z0-9._/-]+$/.test(remote)) {
+    return result('NEEDS_DECISION', ['FlightDeck upstream remote identity is ambiguous.']);
+  }
+
+  try {
+    runGit(git, ['fetch', '--quiet', remote], canonicalProject, 'FlightDeck upstream fetch failed.');
+  } catch (error) {
+    return result('BLOCKED', [error.message]);
+  }
+
+  let counts;
+  try {
+    counts = parseAheadBehind(runGit(
+      git,
+      ['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'],
+      canonicalProject,
+      'FlightDeck upstream relationship could not be inspected.',
+    ));
+  } catch (error) {
+    return result('BLOCKED', [error.message]);
+  }
+  if (!counts) {
+    return result('BLOCKED', ['FlightDeck upstream relationship returned an unsupported result.']);
+  }
+  if (counts.ahead > 0 && counts.behind > 0) {
+    return result('BLOCKED', ['FlightDeck checkout has diverged from its upstream; no Git update or core sync was attempted.']);
+  }
+  if (counts.ahead > 0) {
+    return result('BLOCKED', ['FlightDeck checkout is locally ahead of its upstream; no Git update or core sync was attempted.']);
+  }
+  if (counts.behind === 0) {
+    return result('ALREADY_CURRENT', ['FlightDeck checkout is already at its upstream commit.']);
+  }
+
+  try {
+    runGit(
+      git,
+      ['merge', '--ff-only', '@{upstream}'],
+      canonicalProject,
+      'FlightDeck checkout could not be fast-forwarded safely.',
+    );
+    fastForwardCompleted = true;
+    const after = parseAheadBehind(runGit(
+      git,
+      ['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'],
+      canonicalProject,
+      'FlightDeck fast-forward result could not be verified.',
+    ));
+    const afterStatus = runGit(
+      git,
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      canonicalProject,
+      'FlightDeck working tree could not be verified after fast-forward.',
+    );
+    if (!after || after.ahead !== 0 || after.behind !== 0 || afterStatus !== '') {
+      return result('BLOCKED', ['FlightDeck fast-forward did not leave a clean checkout at its upstream commit.'], true);
+    }
+  } catch (error) {
+    return result('BLOCKED', [error.message], fastForwardCompleted);
+  }
+
+  return result('UPDATED', ['FlightDeck checkout fast-forwarded to its upstream commit.'], true);
+}
+
+export async function maintainFlightDeck(projectName, commandCenterPath, serverUrl, dependencies = {}) {
+  const getProjectImpl = dependencies.getProjectImpl || getProject;
+  const git = dependencies.git || defaultGit;
+  const syncCoreImpl = dependencies.syncCoreImpl || syncManagedCore;
+
+  const project = getProjectImpl(projectName);
+  if (!project) {
+    return result('NEEDS_DECISION', [`FlightDeck project "${projectName}" is not configured in Pilot Manager.`]);
+  }
+  if (!project.path || typeof project.path !== 'string') {
+    return result('NEEDS_DECISION', [`FlightDeck project "${projectName}" has no unambiguous checkout path.`]);
+  }
+
+  const checkout = inspectAndUpdateCheckout(project.path, git);
+  if (REFUSAL_OUTCOMES.has(checkout.outcome)) return checkout;
+
+  let core;
+  try {
+    core = await syncCoreImpl(commandCenterPath, serverUrl);
+  } catch {
+    return result(
+      'BLOCKED',
+      [...checkout.evidence, 'Managed-core sync failed without a governed outcome.'],
+      checkout.checkoutUpdated,
+    );
+  }
+  if (!core || (!SUCCESS_OUTCOMES.has(core.outcome) && !REFUSAL_OUTCOMES.has(core.outcome))) {
+    return result(
+      'BLOCKED',
+      [...checkout.evidence, 'Managed-core sync returned an unsupported outcome.'],
+      checkout.checkoutUpdated,
+    );
+  }
+  if (REFUSAL_OUTCOMES.has(core.outcome)) {
+    return result(core.outcome, [...checkout.evidence, ...(core.evidence || [])], checkout.checkoutUpdated);
+  }
+
+  const outcome = checkout.outcome === 'UPDATED' || core.outcome === 'UPDATED'
+    ? 'UPDATED'
+    : 'ALREADY_CURRENT';
+  return result(outcome, [...checkout.evidence, ...(core.evidence || [])], checkout.checkoutUpdated);
+}

--- a/src/paths.js
+++ b/src/paths.js
@@ -7,6 +7,7 @@ export const CONFIG_FILE = path.join(CONFIG_DIR, 'config.yml');
 export const PROJECTS_FILE = path.join(CONFIG_DIR, 'projects.yml');
 export const ENV_DIR = path.join(CONFIG_DIR, 'env');
 export const LOGS_DIR = path.join(CONFIG_DIR, 'logs');
+export const MANAGED_CORE_STATE_DIR = path.join(CONFIG_DIR, 'managed-core');
 export const LAUNCHD_DIR = path.join(os.homedir(), 'Library', 'LaunchAgents');
 
 export function ensureConfigDir() {

--- a/test/core-sync.test.js
+++ b/test/core-sync.test.js
@@ -266,7 +266,7 @@ describe('syncManagedCore', () => {
 
     assert.equal(interrupted.outcome, 'BLOCKED');
     assert.equal(fs.existsSync(managedCoreStatePath(vault, SERVER)), false);
-    assert.equal(fs.existsSync(path.join(vault, incoming.entries[0].path)), true);
+    assert.equal(fs.lstatSync(path.join(vault, incoming.entries[0].path)).isSymbolicLink(), true);
 
     const retried = await syncManagedCore(vault, SERVER, {
       fetchImpl: async () => responseFor(incoming),

--- a/test/core-sync.test.js
+++ b/test/core-sync.test.js
@@ -1,0 +1,293 @@
+import { describe, it, beforeEach, afterEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-manager-core-home-'));
+const originalHome = process.env.HOME;
+process.env.HOME = TEST_HOME;
+
+const {
+  MANAGED_CORE_ENTRIES,
+  fetchCoreManifest,
+  managedCoreStatePath,
+  syncManagedCore,
+  validateCoreManifest,
+} = await import('../src/core-sync.js');
+
+const SERVER = 'https://flightdeck.example.test';
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function finalizeManifest(entries) {
+  const sorted = [...entries].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  for (const entry of sorted) {
+    entry.sha256 = sha256(entry.content);
+    entry.version = `sha256:${entry.sha256}`;
+  }
+  const releaseMaterial = sorted
+    .map(entry => `${entry.path}\0${entry.kind}\0${entry.sha256}\n`)
+    .join('');
+  return {
+    schema_version: 1,
+    release_version: `sha256:${sha256(releaseMaterial)}`,
+    entries: sorted,
+  };
+}
+
+function manifest(version = 'one') {
+  const symlinkTargets = {
+    '.claude/personas/chief-of-staff.md': '../../agents/chief-of-staff.md',
+    '.claude/personas/flight-engineer.md': '../../agents/flight-engineer.md',
+    '.claude/personas/persona-architect.md': '../../agents/persona-architect.md',
+    '.claude/personas/quartermaster.md': '../../agents/quartermaster.md',
+  };
+  return finalizeManifest(MANAGED_CORE_ENTRIES.map(definition => ({
+    path: definition.path,
+    kind: definition.kind,
+    content: definition.kind === 'symlink'
+      ? symlinkTargets[definition.path]
+      : `# ${definition.path}\n\nrelease ${version}\n`,
+  })));
+}
+
+function responseFor(body, { status = 200, contentType = 'application/json' } = {}) {
+  const bytes = typeof body === 'string'
+    ? Buffer.from(body, 'utf8')
+    : Buffer.from(JSON.stringify(body), 'utf8');
+  return {
+    status,
+    headers: { get: name => name.toLowerCase() === 'content-type' ? contentType : null },
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  };
+}
+
+function installTarget(vault, entry) {
+  const target = path.join(vault, entry.path);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  if (entry.kind === 'symlink') fs.symlinkSync(entry.content, target);
+  else fs.writeFileSync(target, entry.content);
+}
+
+let vault;
+
+beforeEach(() => {
+  vault = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-manager-core-vault-'));
+});
+
+afterEach(() => {
+  fs.rmSync(vault, { recursive: true, force: true });
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('managed-core manifest validation', () => {
+  it('accepts only the exact content-addressed version 1 contract', () => {
+    const candidate = manifest();
+    assert.deepEqual(validateCoreManifest(candidate), candidate);
+  });
+
+  it('refuses a changed entry hash, entry version, or release digest', () => {
+    const badHash = manifest();
+    badHash.entries[5].sha256 = '0'.repeat(64);
+    assert.throws(() => validateCoreManifest(badHash), /content hash/i);
+
+    const badVersion = manifest();
+    badVersion.entries[5].version = `sha256:${'0'.repeat(64)}`;
+    assert.throws(() => validateCoreManifest(badVersion), /entry version/i);
+
+    const badRelease = manifest();
+    badRelease.release_version = `sha256:${'0'.repeat(64)}`;
+    assert.throws(() => validateCoreManifest(badRelease), /release version/i);
+  });
+
+  it('refuses an unknown, duplicate, unsorted, or unsafe managed path', () => {
+    const unknown = manifest();
+    unknown.entries[0].path = '../outside.md';
+    assert.throws(() => validateCoreManifest(unknown), /managed path/i);
+
+    const duplicate = manifest();
+    duplicate.entries[1].path = duplicate.entries[0].path;
+    assert.throws(() => validateCoreManifest(duplicate), /managed path/i);
+
+    const unsorted = manifest();
+    [unsorted.entries[0], unsorted.entries[1]] = [unsorted.entries[1], unsorted.entries[0]];
+    assert.throws(() => validateCoreManifest(unsorted), /sorted/i);
+  });
+
+  it('refuses unsupported kinds, non-scalar UTF-8 content, and escaping symlinks', () => {
+    const badKind = manifest();
+    badKind.entries[5].kind = 'directory';
+    assert.throws(() => validateCoreManifest(badKind), /kind/i);
+
+    const badUnicode = manifest();
+    badUnicode.entries[5].content = '\ud800';
+    assert.throws(() => validateCoreManifest(badUnicode), /UTF-8/i);
+
+    const escaping = manifest();
+    const link = escaping.entries.find(entry => entry.kind === 'symlink');
+    link.content = '../../../../outside.md';
+    finalizeManifest(escaping.entries);
+    assert.throws(() => validateCoreManifest(escaping), /escapes/i);
+  });
+
+  it('decodes the HTTP response as strict UTF-8 JSON', async () => {
+    const bytes = Buffer.from([0xff, 0xfe, 0xfd]);
+    const fetchImpl = async () => ({
+      status: 200,
+      headers: { get: () => 'application/json' },
+      arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    });
+
+    await assert.rejects(fetchCoreManifest(SERVER, { fetchImpl }), /UTF-8/i);
+  });
+});
+
+describe('syncManagedCore', () => {
+  it('installs only missing allowlisted entries, records hashed ownership, and returns UPDATED', async () => {
+    fs.writeFileSync(path.join(vault, 'user-note.md'), 'mine\n');
+    const incoming = manifest();
+    const result = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(incoming),
+    });
+
+    assert.equal(result.outcome, 'UPDATED');
+    assert.equal(result.changedPaths.length, MANAGED_CORE_ENTRIES.length);
+    assert.equal(fs.readFileSync(path.join(vault, 'user-note.md'), 'utf8'), 'mine\n');
+    for (const entry of incoming.entries) {
+      const target = path.join(vault, entry.path);
+      if (entry.kind === 'symlink') assert.equal(fs.readlinkSync(target), entry.content);
+      else assert.equal(fs.readFileSync(target, 'utf8'), entry.content);
+    }
+
+    const statePath = managedCoreStatePath(vault, SERVER);
+    const stateText = fs.readFileSync(statePath, 'utf8');
+    const state = JSON.parse(stateText);
+    assert.equal(state.schema_version, 1);
+    assert.equal(state.release_version, incoming.release_version);
+    assert.equal(Object.keys(state.entries).length, MANAGED_CORE_ENTRIES.length);
+    assert.doesNotMatch(path.basename(statePath), /flightdeck|command-center/i);
+    assert.doesNotMatch(stateText, /flightdeck\.example\.test/);
+  });
+
+  it('returns ALREADY_CURRENT on a repeated no-change run without rewriting state', async () => {
+    const incoming = manifest();
+    const fetchImpl = async () => responseFor(incoming);
+    await syncManagedCore(vault, SERVER, { fetchImpl });
+    const statePath = managedCoreStatePath(vault, SERVER);
+    const before = fs.statSync(statePath).mtimeMs;
+
+    const result = await syncManagedCore(vault, SERVER, { fetchImpl });
+
+    assert.equal(result.outcome, 'ALREADY_CURRENT');
+    assert.deepEqual(result.changedPaths, []);
+    assert.equal(fs.statSync(statePath).mtimeMs, before);
+  });
+
+  it('adopts identical existing content without rewriting it', async () => {
+    const incoming = manifest();
+    incoming.entries.forEach(entry => installTarget(vault, entry));
+    const target = path.join(vault, 'agents', 'flight-engineer.md');
+    const before = fs.statSync(target).mtimeMs;
+
+    const result = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(incoming),
+    });
+
+    assert.equal(result.outcome, 'ALREADY_CURRENT');
+    assert.equal(fs.statSync(target).mtimeMs, before);
+    assert.ok(fs.existsSync(managedCoreStatePath(vault, SERVER)));
+  });
+
+  it('returns NEEDS_DECISION and makes no mutation for unowned differing content', async () => {
+    const incoming = manifest();
+    const target = path.join(vault, 'agents', 'flight-engineer.md');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, '# local flight engineer\n');
+
+    const result = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(incoming),
+    });
+
+    assert.equal(result.outcome, 'NEEDS_DECISION');
+    assert.match(result.evidence.join(' '), /flight-engineer\.md/);
+    assert.equal(fs.readFileSync(target, 'utf8'), '# local flight engineer\n');
+    assert.equal(fs.existsSync(path.join(vault, 'agents', 'chief-of-staff.md')), false);
+    assert.equal(fs.existsSync(managedCoreStatePath(vault, SERVER)), false);
+  });
+
+  it('updates content only when the destination still matches retained ownership state', async () => {
+    const first = manifest('one');
+    const second = manifest('two');
+    await syncManagedCore(vault, SERVER, { fetchImpl: async () => responseFor(first) });
+
+    const result = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(second),
+    });
+
+    assert.equal(result.outcome, 'UPDATED');
+    assert.equal(
+      fs.readFileSync(path.join(vault, 'agents', 'flight-engineer.md'), 'utf8'),
+      second.entries.find(entry => entry.path === 'agents/flight-engineer.md').content,
+    );
+  });
+
+  it('returns BLOCKED before writes when a managed destination was locally modified', async () => {
+    const first = manifest('one');
+    const second = manifest('two');
+    await syncManagedCore(vault, SERVER, { fetchImpl: async () => responseFor(first) });
+    const modified = path.join(vault, 'agents', 'flight-engineer.md');
+    const untouched = path.join(vault, 'agents', 'chief-of-staff.md');
+    fs.writeFileSync(modified, '# local edit\n');
+
+    const result = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(second),
+    });
+
+    assert.equal(result.outcome, 'BLOCKED');
+    assert.match(result.evidence.join(' '), /locally modified/i);
+    assert.equal(fs.readFileSync(modified, 'utf8'), '# local edit\n');
+    assert.equal(
+      fs.readFileSync(untouched, 'utf8'),
+      first.entries.find(entry => entry.path === 'agents/chief-of-staff.md').content,
+    );
+  });
+
+  it('refuses deletion and type ambiguity after ownership was established', async () => {
+    const incoming = manifest();
+    const fetchImpl = async () => responseFor(incoming);
+    await syncManagedCore(vault, SERVER, { fetchImpl });
+    fs.unlinkSync(path.join(vault, 'agents', 'flight-engineer.md'));
+
+    const deleted = await syncManagedCore(vault, SERVER, { fetchImpl });
+    assert.equal(deleted.outcome, 'BLOCKED');
+    assert.match(deleted.evidence.join(' '), /deleted/i);
+
+    fs.mkdirSync(path.join(vault, 'agents', 'flight-engineer.md'));
+    const wrongType = await syncManagedCore(vault, SERVER, { fetchImpl });
+    assert.equal(wrongType.outcome, 'BLOCKED');
+    assert.match(wrongType.evidence.join(' '), /type|locally modified/i);
+  });
+
+  it('validates the complete manifest before any write and reports server unavailability as BLOCKED', async () => {
+    const invalid = manifest();
+    invalid.entries.pop();
+    const invalidResult = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(invalid),
+    });
+    assert.equal(invalidResult.outcome, 'NEEDS_DECISION');
+    assert.equal(fs.existsSync(path.join(vault, 'agents')), false);
+
+    const unavailable = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor({ error: 'unavailable' }, { status: 500 }),
+    });
+    assert.equal(unavailable.outcome, 'BLOCKED');
+  });
+});

--- a/test/core-sync.test.js
+++ b/test/core-sync.test.js
@@ -131,6 +131,10 @@ describe('managed-core manifest validation', () => {
     badUnicode.entries[5].content = '\ud800';
     assert.throws(() => validateCoreManifest(badUnicode), /UTF-8/i);
 
+    const validPair = manifest();
+    validPair.entries[5].content = 'Flight Engineer \ud83d\ude80\n';
+    assert.doesNotThrow(() => validateCoreManifest(finalizeManifest(validPair.entries)));
+
     const escaping = manifest();
     const link = escaping.entries.find(entry => entry.kind === 'symlink');
     link.content = '../../../../outside.md';

--- a/test/core-sync.test.js
+++ b/test/core-sync.test.js
@@ -16,6 +16,7 @@ const {
   syncManagedCore,
   validateCoreManifest,
 } = await import('../src/core-sync.js');
+const { MANAGED_CORE_STATE_DIR } = await import('../src/paths.js');
 
 const SERVER = 'https://flightdeck.example.test';
 
@@ -243,6 +244,68 @@ describe('syncManagedCore', () => {
     );
   });
 
+  it('converges on retry after application stops between atomic path renames', async () => {
+    const incoming = manifest();
+    const realRename = fs.renameSync;
+    let vaultRenames = 0;
+    fs.renameSync = (source, destination) => {
+      if (source.includes(`${path.sep}.pilot-core-`) && ++vaultRenames === 2) {
+        throw new Error('simulated interruption');
+      }
+      return realRename(source, destination);
+    };
+
+    let interrupted;
+    try {
+      interrupted = await syncManagedCore(vault, SERVER, {
+        fetchImpl: async () => responseFor(incoming),
+      });
+    } finally {
+      fs.renameSync = realRename;
+    }
+
+    assert.equal(interrupted.outcome, 'BLOCKED');
+    assert.equal(fs.existsSync(managedCoreStatePath(vault, SERVER)), false);
+    assert.equal(fs.existsSync(path.join(vault, incoming.entries[0].path)), true);
+
+    const retried = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(incoming),
+    });
+    assert.equal(retried.outcome, 'UPDATED');
+    assert.ok(fs.existsSync(managedCoreStatePath(vault, SERVER)));
+  });
+
+  it('adopts the verified incoming set on retry when ownership-state rename failed', async () => {
+    const incoming = manifest();
+    const statePath = managedCoreStatePath(vault, SERVER);
+    const realRename = fs.renameSync;
+    fs.renameSync = (source, destination) => {
+      if (destination === statePath) throw new Error('simulated state-save failure');
+      return realRename(source, destination);
+    };
+
+    let interrupted;
+    try {
+      interrupted = await syncManagedCore(vault, SERVER, {
+        fetchImpl: async () => responseFor(incoming),
+      });
+    } finally {
+      fs.renameSync = realRename;
+    }
+
+    assert.equal(interrupted.outcome, 'BLOCKED');
+    assert.equal(fs.existsSync(statePath), false);
+    for (const entry of incoming.entries) {
+      assert.equal(fs.existsSync(path.join(vault, entry.path)), true);
+    }
+
+    const retried = await syncManagedCore(vault, SERVER, {
+      fetchImpl: async () => responseFor(incoming),
+    });
+    assert.equal(retried.outcome, 'ALREADY_CURRENT');
+    assert.ok(fs.existsSync(statePath));
+  });
+
   it('returns BLOCKED before writes when a managed destination was locally modified', async () => {
     const first = manifest('one');
     const second = manifest('two');
@@ -293,5 +356,36 @@ describe('syncManagedCore', () => {
       fetchImpl: async () => responseFor({ error: 'unavailable' }, { status: 500 }),
     });
     assert.equal(unavailable.outcome, 'BLOCKED');
+  });
+
+  it('refuses identity-valid ownership state behind a symlinked state directory before vault mutation', async () => {
+    const first = manifest('one');
+    const second = manifest('two');
+    await syncManagedCore(vault, SERVER, { fetchImpl: async () => responseFor(first) });
+
+    const managedPath = path.join(vault, 'agents', 'flight-engineer.md');
+    const statePath = managedCoreStatePath(vault, SERVER);
+    const validState = fs.readFileSync(statePath);
+    const attackDirectory = fs.mkdtempSync(path.join(TEST_HOME, 'managed-core-attack-'));
+    fs.writeFileSync(path.join(attackDirectory, path.basename(statePath)), validState);
+    fs.rmSync(MANAGED_CORE_STATE_DIR, { recursive: true });
+    fs.symlinkSync(attackDirectory, MANAGED_CORE_STATE_DIR);
+
+    try {
+      const result = await syncManagedCore(vault, SERVER, {
+        fetchImpl: async () => responseFor(second),
+      });
+
+      assert.equal(result.outcome, 'BLOCKED');
+      assert.match(result.evidence.join(' '), /state directory/i);
+      assert.equal(
+        fs.readFileSync(managedPath, 'utf8'),
+        first.entries.find(entry => entry.path === 'agents/flight-engineer.md').content,
+      );
+    } finally {
+      fs.unlinkSync(MANAGED_CORE_STATE_DIR);
+      fs.rmSync(attackDirectory, { recursive: true, force: true });
+      fs.mkdirSync(MANAGED_CORE_STATE_DIR, { recursive: true });
+    }
   });
 });

--- a/test/maintenance.test.js
+++ b/test/maintenance.test.js
@@ -6,7 +6,15 @@ import path from 'node:path';
 
 const { maintainFlightDeck } = await import('../src/maintenance.js');
 
-function fakeGit(checkout, { dirty = false, detached = false, upstream = 'origin/main', counts = ['0\t0'] } = {}) {
+function fakeGit(checkout, {
+  dirty = false,
+  detached = false,
+  upstream = 'origin/main',
+  remote = 'origin',
+  topLevel = checkout,
+  counts = ['0\t0'],
+  failCommands = [],
+} = {}) {
   const calls = [];
   let countIndex = 0;
   return {
@@ -14,7 +22,8 @@ function fakeGit(checkout, { dirty = false, detached = false, upstream = 'origin
     run(args) {
       calls.push(args);
       const command = args.join(' ');
-      if (command === 'rev-parse --show-toplevel') return `${checkout}\n`;
+      if (failCommands.includes(command)) throw new Error(`failed: ${command}`);
+      if (command === 'rev-parse --show-toplevel') return `${topLevel}\n`;
       if (command === 'status --porcelain=v1 --untracked-files=normal') return dirty ? ' M app.rb\n' : '';
       if (command === 'symbolic-ref --quiet --short HEAD') {
         if (detached) throw new Error('detached');
@@ -24,8 +33,8 @@ function fakeGit(checkout, { dirty = false, detached = false, upstream = 'origin
         if (!upstream) throw new Error('no upstream');
         return `${upstream}\n`;
       }
-      if (command === 'config --get branch.main.remote') return 'origin\n';
-      if (command === 'fetch --quiet origin') return '';
+      if (command === 'config --get branch.main.remote') return `${remote}\n`;
+      if (command === `fetch --quiet ${remote}`) return '';
       if (command === 'rev-list --left-right --count HEAD...@{upstream}') {
         return `${counts[Math.min(countIndex++, counts.length - 1)]}\n`;
       }
@@ -118,6 +127,95 @@ describe('maintainFlightDeck', () => {
     });
     assert.equal(result.outcome, 'NEEDS_DECISION');
     assert.match(result.evidence.join(' '), /not configured/i);
+  });
+
+  it('refuses a configured path that is not the checkout root', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-root-'));
+    const checkout = path.join(root, 'nested');
+    fs.mkdirSync(checkout);
+    const git = fakeGit(checkout, { topLevel: root });
+    let syncCalled = false;
+    const deps = dependencies(checkout, git);
+    deps.syncCoreImpl = async () => { syncCalled = true; return { outcome: 'ALREADY_CURRENT', evidence: [] }; };
+
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+    );
+
+    assert.equal(result.outcome, 'NEEDS_DECISION');
+    assert.match(result.evidence.join(' '), /checkout root/i);
+    assert.equal(syncCalled, false);
+    assert.equal(git.calls.some(args => args[0] === 'fetch'), false);
+  });
+
+  it('refuses an unsafe upstream remote before fetch or core sync', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout, { remote: '--upload-pack=unsafe' });
+    let syncCalled = false;
+    const deps = dependencies(checkout, git);
+    deps.syncCoreImpl = async () => { syncCalled = true; return { outcome: 'ALREADY_CURRENT', evidence: [] }; };
+
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+    );
+
+    assert.equal(result.outcome, 'NEEDS_DECISION');
+    assert.match(result.evidence.join(' '), /remote identity/i);
+    assert.equal(syncCalled, false);
+    assert.equal(git.calls.some(args => args[0] === 'fetch'), false);
+  });
+
+  it('returns BLOCKED without core sync when upstream fetch fails', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout, { failCommands: ['fetch --quiet origin'] });
+    let syncCalled = false;
+    const deps = dependencies(checkout, git);
+    deps.syncCoreImpl = async () => { syncCalled = true; return { outcome: 'ALREADY_CURRENT', evidence: [] }; };
+
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+    );
+
+    assert.equal(result.outcome, 'BLOCKED');
+    assert.match(result.evidence.join(' '), /fetch failed/i);
+    assert.equal(syncCalled, false);
+  });
+
+  it('returns BLOCKED without core sync when fast-forward fails', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout, {
+      counts: ['0\t1'],
+      failCommands: ['merge --ff-only @{upstream}'],
+    });
+    let syncCalled = false;
+    const deps = dependencies(checkout, git);
+    deps.syncCoreImpl = async () => { syncCalled = true; return { outcome: 'ALREADY_CURRENT', evidence: [] }; };
+
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+    );
+
+    assert.equal(result.outcome, 'BLOCKED');
+    assert.match(result.evidence.join(' '), /fast-forwarded safely/i);
+    assert.equal(result.checkoutUpdated, false);
+    assert.equal(syncCalled, false);
+  });
+
+  it('returns BLOCKED without core sync when fast-forward postverification fails', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout, { counts: ['0\t1', '0\t1'] });
+    let syncCalled = false;
+    const deps = dependencies(checkout, git);
+    deps.syncCoreImpl = async () => { syncCalled = true; return { outcome: 'ALREADY_CURRENT', evidence: [] }; };
+
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+    );
+
+    assert.equal(result.outcome, 'BLOCKED');
+    assert.match(result.evidence.join(' '), /did not leave a clean checkout/i);
+    assert.equal(result.checkoutUpdated, true);
+    assert.equal(syncCalled, false);
   });
 
   it('preserves a refusal from core sync, including evidence that a fast-forward already happened', async () => {

--- a/test/maintenance.test.js
+++ b/test/maintenance.test.js
@@ -1,0 +1,138 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const { maintainFlightDeck } = await import('../src/maintenance.js');
+
+function fakeGit(checkout, { dirty = false, detached = false, upstream = 'origin/main', counts = ['0\t0'] } = {}) {
+  const calls = [];
+  let countIndex = 0;
+  return {
+    calls,
+    run(args) {
+      calls.push(args);
+      const command = args.join(' ');
+      if (command === 'rev-parse --show-toplevel') return `${checkout}\n`;
+      if (command === 'status --porcelain=v1 --untracked-files=normal') return dirty ? ' M app.rb\n' : '';
+      if (command === 'symbolic-ref --quiet --short HEAD') {
+        if (detached) throw new Error('detached');
+        return 'main\n';
+      }
+      if (command === 'rev-parse --abbrev-ref --symbolic-full-name @{upstream}') {
+        if (!upstream) throw new Error('no upstream');
+        return `${upstream}\n`;
+      }
+      if (command === 'config --get branch.main.remote') return 'origin\n';
+      if (command === 'fetch --quiet origin') return '';
+      if (command === 'rev-list --left-right --count HEAD...@{upstream}') {
+        return `${counts[Math.min(countIndex++, counts.length - 1)]}\n`;
+      }
+      if (command === 'merge --ff-only @{upstream}') return 'Updating...\n';
+      throw new Error(`unexpected git command: ${command}`);
+    },
+  };
+}
+
+function dependencies(checkout, git, syncResult = { outcome: 'ALREADY_CURRENT', evidence: ['Core crew is current.'], changedPaths: [] }) {
+  return {
+    getProjectImpl: name => name === 'flight-deck' ? { path: checkout, auth_token: 'never expose me' } : null,
+    git,
+    syncCoreImpl: async () => syncResult,
+  };
+}
+
+describe('maintainFlightDeck', () => {
+  it('fetches and fast-forwards a strictly-behind clean checkout, then invokes core sync', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout, { counts: ['0\t2', '0\t0'] });
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', dependencies(checkout, git),
+    );
+
+    assert.equal(result.outcome, 'UPDATED');
+    assert.equal(result.checkoutUpdated, true);
+    assert.ok(git.calls.some(args => args.join(' ') === 'fetch --quiet origin'));
+    assert.ok(git.calls.some(args => args.join(' ') === 'merge --ff-only @{upstream}'));
+  });
+
+  it('returns ALREADY_CURRENT when neither checkout nor core changed', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout);
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', dependencies(checkout, git),
+    );
+
+    assert.equal(result.outcome, 'ALREADY_CURRENT');
+    assert.equal(result.checkoutUpdated, false);
+    assert.equal(git.calls.some(args => args[0] === 'merge'), false);
+  });
+
+  it('returns UPDATED when only core sync changed', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout);
+    const deps = dependencies(checkout, git, {
+      outcome: 'UPDATED', evidence: ['Managed core updated.'], changedPaths: ['agents/flight-engineer.md'],
+    });
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+    );
+
+    assert.equal(result.outcome, 'UPDATED');
+    assert.equal(result.checkoutUpdated, false);
+  });
+
+  it('refuses dirty, detached, missing-upstream, ahead, and diverged checkouts before core sync', async t => {
+    const cases = [
+      ['dirty', { dirty: true }, /dirty/i],
+      ['detached', { detached: true }, /detached/i],
+      ['missing upstream', { upstream: null }, /upstream/i],
+      ['ahead', { counts: ['1\t0'] }, /ahead/i],
+      ['diverged', { counts: ['1\t2'] }, /diverged/i],
+    ];
+
+    for (const [name, gitOptions, evidence] of cases) {
+      await t.test(name, async () => {
+        const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+        const git = fakeGit(checkout, gitOptions);
+        let syncCalled = false;
+        const deps = dependencies(checkout, git);
+        deps.syncCoreImpl = async () => { syncCalled = true; return { outcome: 'ALREADY_CURRENT', evidence: [] }; };
+
+        const result = await maintainFlightDeck(
+          'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+        );
+
+        assert.equal(result.outcome, 'BLOCKED');
+        assert.match(result.evidence.join(' '), evidence);
+        assert.equal(syncCalled, false);
+        assert.equal(git.calls.some(args => args[0] === 'merge'), false);
+      });
+    }
+  });
+
+  it('returns NEEDS_DECISION when the configured project name is unknown', async () => {
+    const result = await maintainFlightDeck('other', '/vault', 'https://flightdeck.example.test', {
+      getProjectImpl: () => null,
+    });
+    assert.equal(result.outcome, 'NEEDS_DECISION');
+    assert.match(result.evidence.join(' '), /not configured/i);
+  });
+
+  it('preserves a refusal from core sync, including evidence that a fast-forward already happened', async () => {
+    const checkout = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-maintain-checkout-'));
+    const git = fakeGit(checkout, { counts: ['0\t1', '0\t0'] });
+    const deps = dependencies(checkout, git, {
+      outcome: 'BLOCKED', evidence: ['Managed file was locally modified.'], changedPaths: [],
+    });
+    const result = await maintainFlightDeck(
+      'flight-deck', checkout, 'https://flightdeck.example.test', deps,
+    );
+
+    assert.equal(result.outcome, 'BLOCKED');
+    assert.equal(result.checkoutUpdated, true);
+    assert.match(result.evidence.join(' '), /fast-forwarded/i);
+    assert.match(result.evidence.join(' '), /locally modified/i);
+  });
+});

--- a/test/managed-cli.test.js
+++ b/test/managed-cli.test.js
@@ -1,0 +1,59 @@
+import { describe, it, afterEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-manager-cli-home-'));
+const originalHome = process.env.HOME;
+process.env.HOME = TEST_HOME;
+
+const { run } = await import('../src/cli.js');
+
+const realExit = process.exit;
+const realError = console.error;
+
+afterEach(() => {
+  process.exit = realExit;
+  console.error = realError;
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+async function captureRefusal(argv) {
+  const output = [];
+  console.error = line => output.push(String(line));
+  process.exit = code => {
+    const error = new Error(`exit ${code}`);
+    error.exitCode = code;
+    throw error;
+  };
+
+  let exitError;
+  try {
+    await run(argv);
+  } catch (error) {
+    exitError = error;
+  }
+  return { exitError, output };
+}
+
+describe('managed command exit contract', () => {
+  it('returns exit 3 and NEEDS_DECISION when sync-core lacks its target', async () => {
+    const { exitError, output } = await captureRefusal(['sync-core']);
+    assert.equal(exitError.exitCode, 3);
+    assert.equal(output[0], 'NEEDS_DECISION');
+  });
+
+  it('returns exit 3 and NEEDS_DECISION when maintain lacks an exact configured project', async () => {
+    const { exitError, output } = await captureRefusal([
+      'maintain', 'not-configured', '--command-center', '/does/not/matter',
+    ]);
+    assert.equal(exitError.exitCode, 3);
+    assert.equal(output[0], 'NEEDS_DECISION');
+    assert.match(output.join(' '), /not configured/i);
+  });
+});


### PR DESCRIPTION
## Why

Existing FlightDeck installations need an idempotent, auditable way to synchronize only FlightDeck-managed core crew assets. The first scheduled Flight Engineer job also needs one bounded command that can safely fast-forward a configured FlightDeck checkout and invoke the same sync without turning daily maintenance into repository repair.

This is the Pilot Manager client half of [FlightDeck #306](https://github.com/radixhound/flight-deck/pull/306) and consumes its committed schema-v1 contract at `566e63c`.

## Actual contract

### `pilot-manager sync-core <command-center-path> [--server URL]`

- Fetches `GET /seed/core-crew/manifest.json` and strictly decodes UTF-8 JSON.
- Requires schema version 1, the exact sorted ten-path allowlist, exact file/symlink kinds, normalized safe relative paths, valid SHA-256 values, content-derived entry versions, and the content-derived release digest.
- Rejects absolute or escaping symlink targets and checks managed-path ancestors before application.
- Preflights all ten destinations before mutation.
- Installs missing paths; adopts already-equal content without rewriting it.
- Returns `NEEDS_DECISION` without mutation when differing existing content has no ownership record.
- Returns `BLOCKED` without mutation when retained managed content was edited, deleted, or changed type.
- Stages changes under the target vault filesystem, applies each file or link by atomic rename, verifies the full applied set, and advances ownership state only afterward.
- Leaves every user-created path outside the allowlist untouched.
- Keeps `pilot-manager seed` create-only.

### Ownership state

Location:

`~/.config/claude-pilot-manager/managed-core/<sha256-key>.json`

The key is derived from the canonical vault path plus canonical server identity. State stores no raw URL, token, credential, file body, or other secret. Before any ownership read, preflight, staging, or vault write, the client requires `~/.config`, the Pilot Manager config root, and `managed-core` to be real non-symlink directories. It pins the state root realpath, device, and inode and rechecks that identity before staging, application, and state save.

Schema:

```json
{
  "schema_version": 1,
  "vault_identity": "sha256:<digest>",
  "server_identity": "sha256:<digest>",
  "release_version": "sha256:<digest>",
  "entries": {
    "<allowlisted-path>": {
      "kind": "file-or-symlink",
      "sha256": "<last-applied-content-digest>"
    }
  }
}
```

### `pilot-manager maintain <flightdeck-project-name> --command-center <path> [--server URL]`

- Resolves one exact configured Pilot Manager project and requires its configured path to be the Git root.
- Requires a clean tree, attached branch, configured upstream remote, and no local-ahead or diverged commits.
- Fetches only the configured upstream remote.
- Runs `git merge --ff-only @{upstream}` only when strictly behind, then verifies a clean tree at the upstream commit. It cannot create a merge commit.
- Invokes the same managed-core implementation afterward.
- Never switches branches, rebases, resets, stashes, cleans, forces, installs dependencies, runs migrations, restarts services, updates Pilot Manager, or performs repository repair.

## Result and exit contract

- `UPDATED` — exit 0; checkout, managed core, or both changed.
- `ALREADY_CURRENT` — exit 0; neither changed.
- `BLOCKED` — exit 2; a known safety or environment precondition refused the operation.
- `NEEDS_DECISION` — exit 3; target, ownership, or contract identity is ambiguous.

Every command prints the token first, followed by concise non-secret evidence.

## Distribution and docs

The active README no longer claims `@radnine/claude-pilot-manager` is published to npm. It now gives the exact current pre-release install and update command:

`npm install -g git+https://github.com/radixhound/pilot-manager.git`

The wording explicitly does not ratify a permanent release policy.

## Verification handoff

The focused Node tests were written before implementation. Per the Leg 2 dispatch, the builder did not execute them; Picard owns execution:

```bash
node --test test/core-sync.test.js
node --test test/maintenance.test.js
node --test test/managed-cli.test.js
```

Static syntax checks and `git diff --check` passed before push. `.github/workflows/ci.yml` now runs Node 22 with `npm ci` and `npm test` on macOS for pushes and pull requests.

## Non-scope

No generic vault synchronization, user-persona overwrite, Pilot Manager self-update, package publish/version/tag policy, Git repair, migrations, service restart, scheduling, repository UI/chat, fleet health, destructive recovery, merge, or changes to the FlightDeck repository.
