### PR TITLE
Add Pilot Manager CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
## Why

Pilot Manager currently has no default-branch GitHub Actions workflow, so feature PR #12 cannot produce the required CI evidence. This bootstrap lands the minimal reusable gate first.

## Gate

- Run on pull requests and pushes.
- macOS runner, Node 22, `npm ci`, then `npm test`.
- Read-only repository permissions.

## Dependency

Merge this before evaluating CI on FlightDeck Leg 2 Pilot Manager PR #12. After it lands, #12 will be retriggered and must pass the registered workflow.

## Non-scope

No product code, package publication, release policy, dependency changes, or merge automation.
